### PR TITLE
Expose jwt

### DIFF
--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -327,3 +327,7 @@ func (c Client) whoAmI() (whoAmIJsonResponse, error) {
 	}
 	return who, nil
 }
+
+func (c Client) GetCurrentJWT() string {
+	return c.options.JWT
+}

--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -327,7 +327,3 @@ func (c Client) whoAmI() (whoAmIJsonResponse, error) {
 	}
 	return who, nil
 }
-
-func (c Client) outputs(verb string, request restRequest) error {
-	return c.reliableRequest(verb, fmt.Sprintf("outputs/%s", c.options.OID), request)
-}

--- a/limacharlie/organization.go
+++ b/limacharlie/organization.go
@@ -90,3 +90,7 @@ func makeSet(arr []Permission) map[string]struct{} {
 	}
 	return m
 }
+
+func (org Organization) GetCurrentJWT() string {
+	return org.client.GetCurrentJWT()
+}

--- a/limacharlie/output.go
+++ b/limacharlie/output.go
@@ -1,6 +1,7 @@
 package limacharlie
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 )
@@ -117,7 +118,7 @@ type genericOutputsByOrgID = map[string]GenericJSON
 // OutputsGeneric fetches all outputs and returns it in outputs
 func (org Organization) OutputsGeneric(outputs interface{}) error {
 	request := makeDefaultRequest(&outputs).withTimeout(10 * time.Second)
-	if err := org.client.outputs(http.MethodGet, request); err != nil {
+	if err := org.outputs(http.MethodGet, request); err != nil {
 		return err
 	}
 	return nil
@@ -142,7 +143,7 @@ func (org Organization) Outputs() (OutputsByName, error) {
 func (org Organization) OutputAdd(output OutputConfig) (OutputConfig, error) {
 	resp := OutputConfig{}
 	request := makeDefaultRequest(&resp).withTimeout(10 * time.Second).withFormData(output)
-	if err := org.client.outputs(http.MethodPost, request); err != nil {
+	if err := org.outputs(http.MethodPost, request); err != nil {
 		return OutputConfig{}, err
 	}
 	return resp, nil
@@ -152,8 +153,12 @@ func (org Organization) OutputAdd(output OutputConfig) (OutputConfig, error) {
 func (org Organization) OutputDel(name string) (GenericJSON, error) {
 	resp := GenericJSON{}
 	request := makeDefaultRequest(&resp).withTimeout(10 * time.Second).withFormData(map[string]string{"name": name})
-	if err := org.client.outputs(http.MethodDelete, request); err != nil {
+	if err := org.outputs(http.MethodDelete, request); err != nil {
 		return nil, err
 	}
 	return resp, nil
+}
+
+func (org Organization) outputs(verb string, request restRequest) error {
+	return org.client.reliableRequest(verb, fmt.Sprintf("outputs/%s", org.client.options.OID), request)
 }


### PR DESCRIPTION
1. Moved the `outputs()` function from the client into the Organization where it better fits within `output.go`.
1. Adding a simple function to expose the currently used JWT.