### PR TITLE
Fix Organization and Firehose to be ptr types.

### DIFF
--- a/firehose/main.go
+++ b/firehose/main.go
@@ -138,7 +138,7 @@ func parseArgs() (FirehoseCLIOptions, error) {
 		nil
 }
 
-func consumeMessages(fh lc.Firehose) {
+func consumeMessages(fh *lc.Firehose) {
 	for !fh.IsRunning() {
 		if len(fh.Messages) == 0 {
 			time.Sleep(1 * time.Second)
@@ -149,7 +149,7 @@ func consumeMessages(fh lc.Firehose) {
 	}
 }
 
-func consumeDroppedMessages(fh lc.Firehose) {
+func consumeDroppedMessages(fh *lc.Firehose) {
 	for !fh.IsRunning() {
 		if len(fh.Messages) == 0 {
 			time.Sleep(1 * time.Second)
@@ -185,13 +185,13 @@ func main() {
 		cliOpts.ClientOpts.APIKey = string(bytesAPIKey)
 	}
 
-	org, err := lc.MakeOrganization(cliOpts.ClientOpts)
+	org, err := lc.NewOrganization(cliOpts.ClientOpts)
 	if err != nil {
 		log.Err(err).Msg("could not make organization")
 		return
 	}
 
-	fh, err := lc.MakeFirehose(org, cliOpts.FirehoseOpts, &cliOpts.FirehoseOutputOpts)
+	fh, err := lc.NewFirehose(org, cliOpts.FirehoseOpts, &cliOpts.FirehoseOutputOpts)
 	if err != nil {
 		log.Err(err).Msg("could not make firehose")
 	}

--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -320,7 +320,7 @@ type whoAmIJsonResponse struct {
 // GenericJSON is the default format for json data
 type GenericJSON = map[string]interface{}
 
-func (c Client) whoAmI() (whoAmIJsonResponse, error) {
+func (c *Client) whoAmI() (whoAmIJsonResponse, error) {
 	who := whoAmIJsonResponse{}
 	if err := c.reliableRequest(http.MethodGet, "who", makeDefaultRequest(&who)); err != nil {
 		return whoAmIJsonResponse{}, err
@@ -328,6 +328,6 @@ func (c Client) whoAmI() (whoAmIJsonResponse, error) {
 	return who, nil
 }
 
-func (c Client) GetCurrentJWT() string {
+func (c *Client) GetCurrentJWT() string {
 	return c.options.JWT
 }

--- a/limacharlie/organization.go
+++ b/limacharlie/organization.go
@@ -6,16 +6,16 @@ import (
 
 // Organization holds a connection to the LC cloud organization
 type Organization struct {
-	client Client
+	client *Client
 }
 
-// MakeOrganization creates an Organization
-func MakeOrganization(clientOpts ClientOptions) (Organization, error) {
+// NewOrganization creates an Organization
+func NewOrganization(clientOpts ClientOptions) (*Organization, error) {
 	c, err := NewClient(clientOpts)
 	if err != nil {
-		return Organization{}, fmt.Errorf("Could not initialize client: %s", err)
+		return nil, fmt.Errorf("Could not initialize client: %s", err)
 	}
-	return Organization{*c}, nil
+	return &Organization{c}, nil
 }
 
 // Permission represents the permission granted in LC
@@ -47,7 +47,7 @@ func arrayExistsInString(key string, arr []string) bool {
 }
 
 // Authorize validate requested permissions for the organization
-func (org Organization) Authorize(permissionsNeeded []string) ([]Permission, error) {
+func (org *Organization) Authorize(permissionsNeeded []string) ([]Permission, error) {
 	effective := NoPermission()
 	result, err := org.client.whoAmI()
 	if err != nil {
@@ -91,6 +91,6 @@ func makeSet(arr []Permission) map[string]struct{} {
 	return m
 }
 
-func (org Organization) GetCurrentJWT() string {
+func (org *Organization) GetCurrentJWT() string {
 	return org.client.GetCurrentJWT()
 }

--- a/limacharlie/test_fixture.go
+++ b/limacharlie/test_fixture.go
@@ -28,8 +28,8 @@ func getTestClientFromEnv(t *testing.T) Client {
 	return *c
 }
 
-func getTestOrgFromEnv(t *testing.T) Organization {
-	org, err := MakeOrganization(getTestOptionsFromEnv(t))
+func getTestOrgFromEnv(t *testing.T) *Organization {
+	org, err := NewOrganization(getTestOptionsFromEnv(t))
 	assertIsNotError(t, err, "failed to make organization")
 	return org
 }


### PR DESCRIPTION
Make the Firehose, Client and Organization objects return as pointers. Also change their builder names accordingly.

This fixes bugs where a value modified within some of the methods would not be reflected in the same object as the caller.