### PR TITLE
Add dr rules

### DIFF
--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -227,7 +227,9 @@ func getStringKV(d interface{}) (map[string]string, error) {
 		return nil, err
 	}
 	o := map[string]interface{}{}
-	if err := json.Unmarshal(b, &o); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.UseNumber()
+	if err := decoder.Decode(&o); err != nil {
 		return nil, err
 	}
 	m := map[string]string{}

--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -78,6 +78,11 @@ func (r restRequest) withFormData(formData interface{}) restRequest {
 	return r
 }
 
+func (r restRequest) withQueryData(queryData interface{}) restRequest {
+	r.queryData = queryData
+	return r
+}
+
 func isEmpty(s string) bool {
 	return len(strings.TrimSpace(s)) == 0
 }

--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -310,13 +310,13 @@ func (c *Client) request(verb string, path string, request restRequest) (int, er
 	// we will perform a CleanUnmarshal to better
 	// interpret large integers to int64 whenever
 	// possible instead of the json's default float64.
-	if originalResponse, ok := request.response.(map[string]interface{}); ok {
+	if originalResponse, ok := request.response.(*map[string]interface{}); ok {
 		tmpResp, err := UnmarshalCleanJSON(respData.String())
 		if err != nil {
 			return resp.StatusCode, err
 		}
 		for k, v := range tmpResp {
-			originalResponse[k] = v
+			(*originalResponse)[k] = v
 		}
 		return resp.StatusCode, nil
 	}

--- a/limacharlie/json.go
+++ b/limacharlie/json.go
@@ -1,0 +1,93 @@
+package limacharlie
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func UnmarshalCleanJSON(data string) (map[string]interface{}, error) {
+	d := json.NewDecoder(strings.NewReader(data))
+	d.UseNumber()
+
+	out := map[string]interface{}{}
+	if err := d.Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if err := unmarshalCleanJSONMap(out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func unmarshalCleanJSONMap(out map[string]interface{}) error {
+	for k, v := range out {
+		switch val := v.(type) {
+		case map[string]interface{}:
+			if err := unmarshalCleanJSONMap(val); err != nil {
+				return err
+			}
+		case []interface{}:
+			if err := unmarshalCleanJSONList(val); err != nil {
+				return err
+			}
+		default:
+			var err error
+			out[k], err = unmarshalCleanJSONElement(val)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func unmarshalCleanJSONList(out []interface{}) error {
+	for i, v := range out {
+		switch val := v.(type) {
+		case map[string]interface{}:
+			if err := unmarshalCleanJSONMap(val); err != nil {
+				return err
+			}
+		case []interface{}:
+			if err := unmarshalCleanJSONList(val); err != nil {
+				return err
+			}
+		default:
+			var err error
+			out[i], err = unmarshalCleanJSONElement(val)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func unmarshalCleanJSONElement(out interface{}) (interface{}, error) {
+	if val, ok := out.(json.Number); ok {
+		// This is a Number, we need to check if it has
+		// a float component originally to see if we should
+		// type it as an int64 or a float64.
+		original := val.String()
+		if !strings.Contains(original, ".") {
+			// No dot component, return as uint64 so
+			// that it gets serialized back to a notation
+			// without a dot in it.
+			i, err := val.Int64()
+			if err != nil {
+				return nil, err
+			}
+			out = i
+		} else {
+			// There is a dot, assume a float.
+			i, err := val.Float64()
+			if err != nil {
+				return nil, err
+			}
+			out = i
+		}
+	}
+	return out, nil
+}

--- a/limacharlie/rule.go
+++ b/limacharlie/rule.go
@@ -113,7 +113,13 @@ func (d CoreDRRule) Equal(dr CoreDRRule) bool {
 	if d.Name != dr.Name {
 		return false
 	}
-	if d.Namespace == dr.Namespace || (d.Namespace == "general" && dr.Namespace == "") || (dr.Namespace == "general" && d.Namespace == "") {
+	if d.Namespace == "" {
+		d.Namespace = "general"
+	}
+	if dr.Namespace == "" {
+		dr.Namespace = "general"
+	}
+	if d.Namespace != dr.Namespace {
 		return false
 	}
 	j1, err := json.Marshal(d.Detect)

--- a/limacharlie/rule.go
+++ b/limacharlie/rule.go
@@ -82,6 +82,8 @@ func (org Organization) DRRules(filters ...DRRuleFilter) (map[string]interface{}
 		f(req)
 	}
 
+	fmt.Println(req)
+
 	resp := map[string]interface{}{}
 
 	request := makeDefaultRequest(&resp).withFormData(req)

--- a/limacharlie/rule.go
+++ b/limacharlie/rule.go
@@ -28,6 +28,13 @@ type drAddRuleRequest struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
+type CoreDRRule struct {
+	Name      string                   `json:"name"`
+	Namespace string                   `json:"namespace,omitempty"`
+	Detect    map[string]interface{}   `json:"detect"`
+	Response  []map[string]interface{} `json:"respond"`
+}
+
 // DRRuleAdd add a D&R Rule to an LC organization
 func (org Organization) DRRuleAdd(name string, detection interface{}, response interface{}, opt ...DRRuleOptions) error {
 	resp := map[string]interface{}{}
@@ -97,4 +104,36 @@ func (org Organization) DRDelRules(name string, optNamespace ...string) error {
 		return err
 	}
 	return nil
+}
+
+func (d CoreDRRule) Equal(dr CoreDRRule) bool {
+	if d.Name != dr.Name {
+		return false
+	}
+	if d.Namespace == dr.Namespace || (d.Namespace == "general" && dr.Namespace == "") || (dr.Namespace == "general" && d.Namespace == "") {
+		return false
+	}
+	j1, err := json.Marshal(d.Detect)
+	if err != nil {
+		return false
+	}
+	j2, err := json.Marshal(dr.Detect)
+	if err != nil {
+		return false
+	}
+	if string(j1) != string(j2) {
+		return false
+	}
+	j1, err = json.Marshal(d.Response)
+	if err != nil {
+		return false
+	}
+	j2, err = json.Marshal(dr.Response)
+	if err != nil {
+		return false
+	}
+	if string(j1) != string(j2) {
+		return false
+	}
+	return true
 }

--- a/limacharlie/rule.go
+++ b/limacharlie/rule.go
@@ -82,11 +82,9 @@ func (org Organization) DRRules(filters ...DRRuleFilter) (map[string]interface{}
 		f(req)
 	}
 
-	fmt.Println(req)
-
 	resp := map[string]interface{}{}
 
-	request := makeDefaultRequest(&resp).withFormData(req)
+	request := makeDefaultRequest(&resp).withQueryData(req)
 	if err := org.client.reliableRequest(http.MethodGet, fmt.Sprintf("rules/%s", org.client.options.OID), request); err != nil {
 		return nil, err
 	}

--- a/limacharlie/rule.go
+++ b/limacharlie/rule.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-type NewDRRuleFilter struct {
+type NewDRRuleOptions struct {
 	// Replace rule if it already exists with this name.
 	IsReplace bool
 	// Rule namespace, defaults to "general".
@@ -38,9 +38,9 @@ type CoreDRRule struct {
 }
 
 // DRRuleAdd add a D&R Rule to an LC organization
-func (org Organization) DRRuleAdd(name string, detection interface{}, response interface{}, opt ...NewDRRuleFilter) error {
+func (org Organization) DRRuleAdd(name string, detection interface{}, response interface{}, opt ...NewDRRuleOptions) error {
 	resp := map[string]interface{}{}
-	reqOpt := NewDRRuleFilter{
+	reqOpt := NewDRRuleOptions{
 		IsEnabled: true,
 	}
 	for _, o := range opt {

--- a/limacharlie/rule_test.go
+++ b/limacharlie/rule_test.go
@@ -25,8 +25,6 @@ func TestDRRuleAddDelete(t *testing.T) {
 		t.Errorf("unexpected preexisting rules in add/delete: %+v", rules)
 	}
 
-	testOutputName := "test-lc-go-sdk-out"
-
 	testRuleName := "testrule"
 	testRuleExp := int64(3600)
 	testRuleDetect := map[string]interface{}{
@@ -50,11 +48,11 @@ func TestDRRuleAddDelete(t *testing.T) {
 	a.NoError(err)
 	if len(rules) == 0 {
 		t.Errorf("rules is empty")
-	} else if _, ok := rules[testOutputName]; !ok {
+	} else if _, ok := rules[testRuleName]; !ok {
 		t.Errorf("test rule not found: %+v", rules)
 	}
 
-	_, err = org.OutputDel(testOutputName)
+	_, err = org.OutputDel(testRuleName)
 	a.NoError(err)
 
 	rules, err = org.DRRules()

--- a/limacharlie/rule_test.go
+++ b/limacharlie/rule_test.go
@@ -38,7 +38,7 @@ func TestDRRuleAddDelete(t *testing.T) {
 		"name":   "test",
 	}}
 
-	err = org.DRRuleAdd(testRuleName, testRuleDetect, testRuleResponse, DRRuleOptions{
+	err = org.DRRuleAdd(testRuleName, testRuleDetect, testRuleResponse, NewDRRuleOptions{
 		IsEnabled: true,
 		TTL:       testRuleExp,
 	})

--- a/limacharlie/rule_test.go
+++ b/limacharlie/rule_test.go
@@ -52,7 +52,7 @@ func TestDRRuleAddDelete(t *testing.T) {
 		t.Errorf("test rule not found: %+v", rules)
 	}
 
-	_, err = org.OutputDel(testRuleName)
+	err = org.DRDelRules(testRuleName)
 	a.NoError(err)
 
 	rules, err = org.DRRules()

--- a/limacharlie/rule_test.go
+++ b/limacharlie/rule_test.go
@@ -44,7 +44,7 @@ func TestDRRuleAddDelete(t *testing.T) {
 	})
 	a.NoError(err)
 
-	rules, err = org.DRRules()
+	rules, err = org.DRRules(WithNamespace("general"))
 	a.NoError(err)
 	if len(rules) == 0 {
 		t.Errorf("rules is empty")

--- a/limacharlie/rule_test.go
+++ b/limacharlie/rule_test.go
@@ -1,0 +1,65 @@
+package limacharlie
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDRRuleList(t *testing.T) {
+	a := assert.New(t)
+	org := getTestOrgFromEnv(a)
+	rules, err := org.DRRules()
+	a.NoError(err)
+	if len(rules) != 0 {
+		t.Errorf("unexpected preexisting rules in list: %+v", rules)
+	}
+}
+
+func TestDRRuleAddDelete(t *testing.T) {
+	a := assert.New(t)
+	org := getTestOrgFromEnv(a)
+	rules, err := org.DRRules()
+	a.NoError(err)
+	if len(rules) != 0 {
+		t.Errorf("unexpected preexisting rules in add/delete: %+v", rules)
+	}
+
+	testOutputName := "test-lc-go-sdk-out"
+
+	testRuleName := "testrule"
+	testRuleExp := int64(3600)
+	testRuleDetect := map[string]interface{}{
+		"op":    "is",
+		"event": "NEW_PROCESS",
+		"path":  "event/nope",
+		"value": "never",
+	}
+	testRuleResponse := []map[string]interface{}{{
+		"action": "report",
+		"name":   "test",
+	}}
+
+	err = org.DRRuleAdd(testRuleName, testRuleDetect, testRuleResponse, DRRuleOptions{
+		IsEnabled: true,
+		TTL:       testRuleExp,
+	})
+	a.NoError(err)
+
+	rules, err = org.DRRules()
+	a.NoError(err)
+	if len(rules) == 0 {
+		t.Errorf("rules is empty")
+	} else if _, ok := rules[testOutputName]; !ok {
+		t.Errorf("test rule not found: %+v", rules)
+	}
+
+	_, err = org.OutputDel(testOutputName)
+	a.NoError(err)
+
+	rules, err = org.DRRules()
+	a.NoError(err)
+	if len(rules) != 0 {
+		t.Errorf("rules is not empty")
+	}
+}


### PR DESCRIPTION
- Add support for D&R rules basic ops.
- Fix deserialization from API responses to generic struct (map[string]interface{}) and large numbers (int64 vs float64).
- Basic tests.