### PR TITLE
Early Sync

### DIFF
--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -356,7 +356,7 @@ func (c *Client) GetCurrentJWT() string {
 	return c.options.JWT
 }
 
-func (w whoAmIJsonResponse) checkPermission(oid string, permName string) bool {
+func (w whoAmIJsonResponse) hasPermissionForOrg(oid string, permName string) bool {
 	if w.UserPermissions != nil {
 		if p, ok := (*w.UserPermissions)[oid]; ok {
 			for _, v := range p {

--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -355,3 +355,37 @@ func (c *Client) whoAmI() (whoAmIJsonResponse, error) {
 func (c *Client) GetCurrentJWT() string {
 	return c.options.JWT
 }
+
+func (w whoAmIJsonResponse) checkPermission(oid string, permName string) bool {
+	if w.UserPermissions != nil {
+		if p, ok := (*w.UserPermissions)[oid]; ok {
+			for _, v := range p {
+				if permName == v {
+					return true
+				}
+			}
+		}
+	}
+	if w.Organizations == nil || w.Permissions == nil {
+		return false
+	}
+	isOrgFound := false
+	for _, o := range *w.Organizations {
+		if o == oid {
+			isOrgFound = true
+			break
+		}
+	}
+	if !isOrgFound {
+		return false
+	}
+	if permName == "" {
+		return true
+	}
+	for _, p := range *w.Permissions {
+		if p == permName {
+			return true
+		}
+	}
+	return false
+}

--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -379,13 +379,32 @@ func (w whoAmIJsonResponse) hasPermissionForOrg(oid string, permName string) boo
 	if !isOrgFound {
 		return false
 	}
-	if permName == "" {
-		return true
-	}
 	for _, p := range *w.Permissions {
 		if p == permName {
 			return true
 		}
 	}
 	return false
+}
+
+func (w whoAmIJsonResponse) hasAccessToOrg(oid string) bool {
+	if w.UserPermissions != nil {
+		if _, ok := (*w.UserPermissions)[oid]; ok {
+			return true
+		}
+	}
+	if w.Organizations == nil || w.Permissions == nil {
+		return false
+	}
+	isOrgFound := false
+	for _, o := range *w.Organizations {
+		if o == oid {
+			isOrgFound = true
+			break
+		}
+	}
+	if !isOrgFound {
+		return false
+	}
+	return true
 }

--- a/limacharlie/errors.go
+++ b/limacharlie/errors.go
@@ -59,3 +59,6 @@ func (e RESTError) Error() string {
 
 // ErrorResourceNotFound is returned when querying for a resource that does not exist or that the client does not have the permission to see
 var ErrorResourceNotFound = errors.New("resource not found")
+
+// Returned for a feature that is not yet implemented to parity with the Python SDK.
+var ErrorNotImplemented = errors.New("not implemented")

--- a/limacharlie/json.go
+++ b/limacharlie/json.go
@@ -5,6 +5,29 @@ import (
 	"strings"
 )
 
+type Dict map[string]interface{}
+type List []interface{}
+
+func (d *Dict) UnmarshalJSON(data []byte) error {
+	c, err := UnmarshalCleanJSON(string(data))
+	if err != nil {
+		return err
+	}
+	*d = c
+
+	return nil
+}
+
+func (l *List) UnmarshalJSON(data []byte) error {
+	c, err := UnmarshalCleanJSONList(string(data))
+	if err != nil {
+		return err
+	}
+	*l = c
+
+	return nil
+}
+
 func UnmarshalCleanJSON(data string) (map[string]interface{}, error) {
 	d := json.NewDecoder(strings.NewReader(data))
 	d.UseNumber()
@@ -15,6 +38,22 @@ func UnmarshalCleanJSON(data string) (map[string]interface{}, error) {
 	}
 
 	if err := unmarshalCleanJSONMap(out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func UnmarshalCleanJSONList(data string) ([]interface{}, error) {
+	d := json.NewDecoder(strings.NewReader(data))
+	d.UseNumber()
+
+	out := []interface{}{}
+	if err := d.Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if err := unmarshalCleanJSONList(out); err != nil {
 		return nil, err
 	}
 
@@ -90,4 +129,16 @@ func unmarshalCleanJSONElement(out interface{}) (interface{}, error) {
 		}
 	}
 	return out, nil
+}
+
+func (d Dict) UnMarshalToStruct(out interface{}) error {
+	tmp, err := json.Marshal(d)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(tmp, out); err != nil {
+		return err
+	}
+	return nil
 }

--- a/limacharlie/rule.go
+++ b/limacharlie/rule.go
@@ -110,9 +110,6 @@ func (org Organization) DRDelRule(name string, filters ...DRRuleFilter) error {
 }
 
 func (d CoreDRRule) Equal(dr CoreDRRule) bool {
-	if d.Name != dr.Name {
-		return false
-	}
 	if !d.IsInSameNamespace(dr) {
 		return false
 	}

--- a/limacharlie/rule.go
+++ b/limacharlie/rule.go
@@ -31,10 +31,10 @@ type drAddRuleRequest struct {
 }
 
 type CoreDRRule struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace,omitempty"`
-	Detect    Dict   `json:"detect"`
-	Response  List   `json:"respond"`
+	Name      string `json:"name" yaml:"name"`
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Detect    Dict   `json:"detect" yaml:"detect"`
+	Response  List   `json:"respond" yaml:"respond"`
 }
 
 // DRRuleAdd add a D&R Rule to an LC organization

--- a/limacharlie/rule.go
+++ b/limacharlie/rule.go
@@ -92,7 +92,7 @@ func (org Organization) DRRules(filters ...DRRuleFilter) (map[string]Dict, error
 }
 
 // DRDelRule delete a D&R rule from an LC organization
-func (org Organization) DRDelRules(name string, filters ...DRRuleFilter) error {
+func (org Organization) DRDelRule(name string, filters ...DRRuleFilter) error {
 	req := map[string]string{
 		"name": name,
 	}
@@ -113,13 +113,7 @@ func (d CoreDRRule) Equal(dr CoreDRRule) bool {
 	if d.Name != dr.Name {
 		return false
 	}
-	if d.Namespace == "" {
-		d.Namespace = "general"
-	}
-	if dr.Namespace == "" {
-		dr.Namespace = "general"
-	}
-	if d.Namespace != dr.Namespace {
+	if !d.IsInSameNamespace(dr) {
 		return false
 	}
 	j1, err := json.Marshal(d.Detect)
@@ -142,6 +136,19 @@ func (d CoreDRRule) Equal(dr CoreDRRule) bool {
 		return false
 	}
 	if string(j1) != string(j2) {
+		return false
+	}
+	return true
+}
+
+func (d CoreDRRule) IsInSameNamespace(dr CoreDRRule) bool {
+	if d.Namespace == "" {
+		d.Namespace = "general"
+	}
+	if dr.Namespace == "" {
+		dr.Namespace = "general"
+	}
+	if d.Namespace != dr.Namespace {
 		return false
 	}
 	return true

--- a/limacharlie/rule.go
+++ b/limacharlie/rule.go
@@ -31,15 +31,15 @@ type drAddRuleRequest struct {
 }
 
 type CoreDRRule struct {
-	Name      string                   `json:"name"`
-	Namespace string                   `json:"namespace,omitempty"`
-	Detect    map[string]interface{}   `json:"detect"`
-	Response  []map[string]interface{} `json:"respond"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	Detect    Dict   `json:"detect"`
+	Response  List   `json:"respond"`
 }
 
 // DRRuleAdd add a D&R Rule to an LC organization
 func (org Organization) DRRuleAdd(name string, detection interface{}, response interface{}, opt ...NewDRRuleOptions) error {
-	resp := map[string]interface{}{}
+	resp := Dict{}
 	reqOpt := NewDRRuleOptions{
 		IsEnabled: true,
 	}
@@ -75,14 +75,14 @@ func (org Organization) DRRuleAdd(name string, detection interface{}, response i
 }
 
 // DRRules get all D&R rules for an LC organization
-func (org Organization) DRRules(filters ...DRRuleFilter) (map[string]interface{}, error) {
+func (org Organization) DRRules(filters ...DRRuleFilter) (map[string]Dict, error) {
 	req := map[string]string{}
 
 	for _, f := range filters {
 		f(req)
 	}
 
-	resp := map[string]interface{}{}
+	resp := map[string]Dict{}
 
 	request := makeDefaultRequest(&resp).withQueryData(req)
 	if err := org.client.reliableRequest(http.MethodGet, fmt.Sprintf("rules/%s", org.client.options.OID), request); err != nil {
@@ -100,7 +100,7 @@ func (org Organization) DRDelRules(name string, filters ...DRRuleFilter) error {
 		f(req)
 	}
 
-	resp := map[string]interface{}{}
+	resp := Dict{}
 
 	request := makeDefaultRequest(&resp).withFormData(req)
 	if err := org.client.reliableRequest(http.MethodDelete, fmt.Sprintf("rules/%s", org.client.options.OID), request); err != nil {

--- a/limacharlie/rule.go
+++ b/limacharlie/rule.go
@@ -145,10 +145,7 @@ func (d CoreDRRule) IsInSameNamespace(dr CoreDRRule) bool {
 	if dr.Namespace == "" {
 		dr.Namespace = "general"
 	}
-	if d.Namespace != dr.Namespace {
-		return false
-	}
-	return true
+	return d.Namespace == dr.Namespace
 }
 
 func WithNamespace(namespace string) func(map[string]string) {

--- a/limacharlie/rule_test.go
+++ b/limacharlie/rule_test.go
@@ -52,7 +52,7 @@ func TestDRRuleAddDelete(t *testing.T) {
 		t.Errorf("test rule not found: %+v", rules)
 	}
 
-	err = org.DRDelRules(testRuleName)
+	err = org.DRDelRule(testRuleName)
 	a.NoError(err)
 
 	rules, err = org.DRRules()

--- a/limacharlie/run_test.sh
+++ b/limacharlie/run_test.sh
@@ -1,6 +1,8 @@
 #! /bin/sh
 
+set -e
+
 go test -c .
 
 sudo docker build -t limacharlie_tests -f Dockerfile .
-sudo docker run -e _OID=$LC_TEST_OID -e _KEY=$LC_TEST_KEY limacharlie_tests:latest
+sudo docker run --rm -e _OID=$LC_TEST_OID -e _KEY=$LC_TEST_KEY limacharlie_tests:latest

--- a/limacharlie/sync.go
+++ b/limacharlie/sync.go
@@ -49,8 +49,7 @@ type OrgSyncOperation struct {
 }
 
 func (org Organization) SyncFetch(options SyncOptions) (OrgConfig, error) {
-	// TODO
-	return OrgConfig{}, nil
+	return OrgConfig{}, ErrorNotImplemented
 }
 
 func (org Organization) SyncPush(conf OrgConfig, options SyncOptions) ([]OrgSyncOperation, error) {
@@ -64,7 +63,7 @@ func (org Organization) SyncPush(conf OrgConfig, options SyncOptions) ([]OrgSync
 	// Order matters to minimize issues
 	// of dependance between components.
 	if options.SyncResources {
-		// TODO
+		return ops, ErrorNotImplemented
 	}
 	if options.SyncDRRules {
 		newOps, err := org.syncDRRules(who, conf.DRRules, options)
@@ -74,22 +73,22 @@ func (org Organization) SyncPush(conf OrgConfig, options SyncOptions) ([]OrgSync
 		}
 	}
 	if options.SyncFPRules {
-		// TODO
+		return ops, ErrorNotImplemented
 	}
 	if options.SyncOutputs {
-		// TODO
+		return ops, ErrorNotImplemented
 	}
 	if options.SyncIntegrity {
-		// TODO
+		return ops, ErrorNotImplemented
 	}
 	if options.SyncArtifacts {
-		// TODO
+		return ops, ErrorNotImplemented
 	}
 	if options.SyncExfil {
-		// TODO
+		return ops, ErrorNotImplemented
 	}
 	if options.SyncNetPolicies {
-		// TODO
+		return ops, ErrorNotImplemented
 	}
 
 	return ops, nil

--- a/limacharlie/sync.go
+++ b/limacharlie/sync.go
@@ -35,7 +35,7 @@ type SyncOptions struct {
 type DRRuleName = string
 
 type OrgConfig struct {
-	DRRules map[DRRuleName]CoreDRRule `json:"rules"`
+	DRRules map[DRRuleName]CoreDRRule `json:"rules" yaml:"rules"`
 }
 
 type OrgSyncOperation struct {

--- a/limacharlie/sync.go
+++ b/limacharlie/sync.go
@@ -98,13 +98,13 @@ func (org Organization) SyncPush(conf OrgConfig, options SyncOptions) ([]OrgSync
 func (org Organization) syncDRRules(who whoAmIJsonResponse, rules map[DRRuleName]CoreDRRule, options SyncOptions) ([]OrgSyncOperation, error) {
 	// Check which namespaces we have available.
 	availableNamespaces := map[string]struct{}{}
-	if who.checkPermission(org.client.options.OID, "dr.list") {
+	if who.hasPermissionForOrg(org.client.options.OID, "dr.list") {
 		availableNamespaces["general"] = struct{}{}
 	}
-	if who.checkPermission(org.client.options.OID, "dr.list.managed") {
+	if who.hasPermissionForOrg(org.client.options.OID, "dr.list.managed") {
 		availableNamespaces["managed"] = struct{}{}
 	}
-	if who.checkPermission(org.client.options.OID, "dr.list.replicant") {
+	if who.hasPermissionForOrg(org.client.options.OID, "dr.list.replicant") {
 		availableNamespaces["replicant"] = struct{}{}
 	}
 

--- a/limacharlie/sync.go
+++ b/limacharlie/sync.go
@@ -1,0 +1,191 @@
+package limacharlie
+
+import "strings"
+
+const (
+	OrgConfigLatestVersion = 3
+)
+
+// Describes which configuration
+// types to Sync.
+type SyncOptions struct {
+	// Force makes the remove Org an exact mirror of the
+	// configuration provided, adding and removing.
+	// Otherwise elements will only be added, not removed.
+	IsForce bool
+
+	// IgnoreInaccessible ignores elements that are
+	// locked and cannot be modified by the credentials
+	// currently in use.
+	IsIgnoreInaccessible bool
+
+	// Only simulate changes to the Org.
+	IsDryRun bool
+
+	SyncDRRules     bool
+	SyncOutputs     bool
+	SyncResources   bool
+	SyncIntegrity   bool
+	SyncFPRules     bool
+	SyncExfil       bool
+	SyncArtifacts   bool
+	SyncNetPolicies bool
+}
+
+type DRRuleName = string
+
+type OrgConfig struct {
+	DRRules map[DRRuleName]CoreDRRule `json:"rules"`
+}
+
+type OrgSyncOperation struct {
+	ElementType string `json:"type"`
+	ElementName string `json:"name"`
+	IsAdded     bool   `json:"is_added"`
+	IsRemoved   bool   `json:"is_removed"`
+}
+
+func (org Organization) SyncFetch(options SyncOptions) (OrgConfig, error) {
+	// TODO
+	return OrgConfig{}, nil
+}
+
+func (org Organization) SyncPush(conf OrgConfig, options SyncOptions) ([]OrgSyncOperation, error) {
+	ops := []OrgSyncOperation{}
+
+	who, err := org.client.whoAmI()
+	if err != nil {
+		return ops, err
+	}
+
+	// Order matters to minimize issues
+	// of dependance between components.
+	if options.SyncResources {
+		// TODO
+	}
+	if options.SyncDRRules {
+		newOps, err := org.syncDRRules(who, conf.DRRules, options)
+		ops = append(ops, newOps...)
+		if err != nil {
+			return ops, err
+		}
+	}
+	if options.SyncFPRules {
+		// TODO
+	}
+	if options.SyncOutputs {
+		// TODO
+	}
+	if options.SyncIntegrity {
+		// TODO
+	}
+	if options.SyncArtifacts {
+		// TODO
+	}
+	if options.SyncExfil {
+		// TODO
+	}
+	if options.SyncNetPolicies {
+		// TODO
+	}
+
+	return ops, nil
+}
+
+func (org Organization) syncDRRules(who whoAmIJsonResponse, rules map[DRRuleName]CoreDRRule, options SyncOptions) ([]OrgSyncOperation, error) {
+	// Check which namespaces we have available.
+	availableNamespaces := map[string]struct{}{}
+	if who.checkPermission(org.client.options.OID, "dr.list") {
+		availableNamespaces["general"] = struct{}{}
+	}
+	if who.checkPermission(org.client.options.OID, "dr.list.managed") {
+		availableNamespaces["managed"] = struct{}{}
+	}
+	if who.checkPermission(org.client.options.OID, "dr.list.replicant") {
+		availableNamespaces["replicant"] = struct{}{}
+	}
+
+	ops := []OrgSyncOperation{}
+	existingRules := map[DRRuleName]CoreDRRule{}
+
+	// Get rules from all the namespaces we have access to.
+	for ns := range availableNamespaces {
+		tmpRules, err := org.DRRules(WithNamespace(ns))
+		if err != nil {
+			return ops, err
+		}
+		for ruleName, rule := range tmpRules {
+			parsedRule := CoreDRRule{}
+			if err := rule.UnMarshalToStruct(&parsedRule); err != nil {
+				return ops, err
+			}
+			existingRules[ruleName] = parsedRule
+		}
+	}
+
+	// Start by adding missing rules.
+	for ruleName, rule := range rules {
+		if existingRule, ok := existingRules[ruleName]; ok {
+			// A rule with that name is already there.
+			// Is it the exact same rule?
+			if existingRule.Equal(rule) {
+				ops = append(ops, OrgSyncOperation{ElementType: "dr-rule", ElementName: ruleName})
+				// Nothing to do, move on.
+				continue
+			}
+			// If this is a DryRun, just report the op and move on.
+			if options.IsDryRun {
+				ops = append(ops, OrgSyncOperation{ElementType: "dr-rule", ElementName: ruleName, IsAdded: true})
+				continue
+			}
+			// It must be replaced.
+			// If they are in different namespaces, we must
+			// delete the old one before setting the new one.
+			if !existingRule.IsInSameNamespace(rule) {
+				existingNs := existingRule.Namespace
+				if existingNs == "" {
+					existingNs = "general"
+				}
+				if err := org.DRDelRule(ruleName, WithNamespace(existingNs)); err != nil {
+					return ops, err
+				}
+			}
+		}
+		if err := org.DRRuleAdd(ruleName, rule.Detect, rule.Response, NewDRRuleOptions{
+			IsReplace: true,
+			Namespace: rule.Namespace,
+			IsEnabled: true,
+		}); err != nil {
+			return ops, err
+		}
+		ops = append(ops, OrgSyncOperation{ElementType: "dr-rule", ElementName: ruleName, IsAdded: true})
+	}
+
+	// If we're not Forcing, then we're done.
+	if !options.IsForce {
+		return ops, nil
+	}
+
+	// Remove rules that no longer exist.
+	for ruleName, rule := range existingRules {
+		if strings.HasPrefix(ruleName, "__") {
+			// Ignore legacy special service rules.
+			continue
+		}
+		if _, ok := rules[ruleName]; ok {
+			// Still there.
+			continue
+		}
+		// If this is a DryRun, report the op and move on.
+		if options.IsDryRun {
+			ops = append(ops, OrgSyncOperation{ElementType: "dr-rule", ElementName: ruleName, IsRemoved: true})
+			continue
+		}
+		if err := org.DRDelRule(ruleName, WithNamespace(rule.Namespace)); err != nil {
+			return ops, err
+		}
+		ops = append(ops, OrgSyncOperation{ElementType: "dr-rule", ElementName: ruleName, IsRemoved: true})
+	}
+
+	return ops, nil
+}

--- a/limacharlie/sync.go
+++ b/limacharlie/sync.go
@@ -151,6 +151,10 @@ func (org Organization) syncDRRules(who whoAmIJsonResponse, rules map[DRRuleName
 				}
 			}
 		}
+		if options.IsDryRun {
+			ops = append(ops, OrgSyncOperation{ElementType: "dr-rule", ElementName: ruleName, IsAdded: true})
+			continue
+		}
 		if err := org.DRRuleAdd(ruleName, rule.Detect, rule.Response, NewDRRuleOptions{
 			IsReplace: true,
 			Namespace: rule.Namespace,

--- a/limacharlie/sync_test.go
+++ b/limacharlie/sync_test.go
@@ -174,10 +174,18 @@ rules:
 		t.Errorf("managed rules has: %+v", rules)
 	}
 
-	err = org.DRDelRule("r1", WithNamespace("general"))
+	ops, err = org.SyncPush(OrgConfig{}, SyncOptions{
+		SyncDRRules: true,
+		IsForce: true,
+	})
 	a.NoError(err)
-	err = org.DRDelRule("r2", WithNamespace("general"))
-	a.NoError(err)
-	err = org.DRDelRule("r3", WithNamespace("general"))
-	a.NoError(err)
+
+	if len(ops) != 3 {
+		t.Errorf("unexpected ops: %+v", err)
+	}
+	for _, o := range ops {
+		if !o.IsRemoved {
+			t.Errorf("non-remove op: %+v", o)
+		}
+	}
 }

--- a/limacharlie/sync_test.go
+++ b/limacharlie/sync_test.go
@@ -23,7 +23,7 @@ rules:
       event: NEW_PROCESS
       path: event/FILE_PATH
       value: nope1
-    respons:
+    respond:
       - action: report
         name: t1
   r2:
@@ -32,7 +32,7 @@ rules:
       event: NEW_PROCESS
       path: event/FILE_PATH
       value: nope2
-    respons:
+    respond:
       - action: report
         name: t2
   r3:
@@ -42,7 +42,7 @@ rules:
       event: NEW_PROCESS
       path: event/FILE_PATH
       value: nope3
-    respons:
+    respond:
       - action: report
         name: t3
 `

--- a/limacharlie/sync_test.go
+++ b/limacharlie/sync_test.go
@@ -1,0 +1,55 @@
+package limacharlie
+
+import (
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+	"testing"
+)
+
+func TestSyncPush(t *testing.T) {
+	a := assert.New(t)
+	org := getTestOrgFromEnv(a)
+	rules, err := org.DRRules()
+	a.NoError(err)
+	if len(rules) != 0 {
+		t.Errorf("unexpected preexisting rules in add/delete: %+v", rules)
+	}
+
+	yc := `
+rules:
+  r1:
+    op: is
+    event: NEW_PROCESS
+    path: event/FILE_PATH
+    value: nope1
+  r2:
+    op: is
+    event: NEW_PROCESS
+    path: event/FILE_PATH
+    value: nope2
+  r3:
+    namespace: managed
+    op: is
+    event: NEW_PROCESS
+    path: event/FILE_PATH
+    value: nope3
+`
+	c := OrgConfig{}
+	if err := yaml.Unmarshal([]byte(yc), c); err != nil {
+		t.Errorf("yaml.Unmarshal: %v", err)
+	}
+
+	if len(c.DRRules) != 3 {
+		t.Errorf("unexpected conf: %+v", c)
+	}
+
+	ops, err := org.SyncPush(c, SyncOptions{
+		IsDryRun:    true,
+		SyncDRRules: true,
+	})
+	a.NoError(err)
+
+	if len(ops) != 3 {
+		t.Errorf("unexpected ops: %+v", err)
+	}
+}

--- a/limacharlie/sync_test.go
+++ b/limacharlie/sync_test.go
@@ -176,7 +176,7 @@ rules:
 
 	ops, err = org.SyncPush(OrgConfig{}, SyncOptions{
 		SyncDRRules: true,
-		IsForce: true,
+		IsForce:     true,
 	})
 	a.NoError(err)
 

--- a/limacharlie/sync_test.go
+++ b/limacharlie/sync_test.go
@@ -1,7 +1,7 @@
 package limacharlie
 
 import (
-	"github.com/stretchr/testify/assert"
+	//"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 	"testing"
 )
@@ -18,24 +18,36 @@ func TestSyncPush(t *testing.T) {
 	yc := `
 rules:
   r1:
-    op: is
-    event: NEW_PROCESS
-    path: event/FILE_PATH
-    value: nope1
+    detect:
+      op: is
+      event: NEW_PROCESS
+      path: event/FILE_PATH
+      value: nope1
+    respons:
+      - action: report
+        name: t1
   r2:
-    op: is
-    event: NEW_PROCESS
-    path: event/FILE_PATH
-    value: nope2
+    detect:
+      op: is
+      event: NEW_PROCESS
+      path: event/FILE_PATH
+      value: nope2
+    respons:
+      - action: report
+        name: t2
   r3:
     namespace: managed
-    op: is
-    event: NEW_PROCESS
-    path: event/FILE_PATH
-    value: nope3
+    detect:
+      op: is
+      event: NEW_PROCESS
+      path: event/FILE_PATH
+      value: nope3
+    respons:
+      - action: report
+        name: t3
 `
 	c := OrgConfig{}
-	if err := yaml.Unmarshal([]byte(yc), c); err != nil {
+	if err := yaml.Unmarshal([]byte(yc), &c); err != nil {
 		t.Errorf("yaml.Unmarshal: %v", err)
 	}
 

--- a/limacharlie/sync_test.go
+++ b/limacharlie/sync_test.go
@@ -1,7 +1,7 @@
 package limacharlie
 
 import (
-	//"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 	"testing"
 )

--- a/limacharlie/sync_test.go
+++ b/limacharlie/sync_test.go
@@ -47,9 +47,8 @@ rules:
         name: t3
 `
 	c := OrgConfig{}
-	if err := yaml.Unmarshal([]byte(yc), &c); err != nil {
-		t.Errorf("yaml.Unmarshal: %v", err)
-	}
+	err = yaml.Unmarshal([]byte(yc), &c)
+	a.NoError(err)
 
 	if len(c.DRRules) != 3 {
 		t.Errorf("unexpected conf: %+v", c)
@@ -64,4 +63,121 @@ rules:
 	if len(ops) != 3 {
 		t.Errorf("unexpected ops: %+v", err)
 	}
+	for _, o := range ops {
+		if !o.IsAdded {
+			t.Errorf("non-add op: %+v", o)
+		}
+	}
+
+	rules, err = org.DRRules(WithNamespace("general"))
+	a.NoError(err)
+	if len(rules) != 0 {
+		t.Errorf("general rules is not empty")
+	}
+	rules, err = org.DRRules(WithNamespace("managed"))
+	a.NoError(err)
+	if len(rules) != 0 {
+		t.Errorf("managed rules is not empty")
+	}
+
+	ops, err = org.SyncPush(c, SyncOptions{
+		SyncDRRules: true,
+	})
+	a.NoError(err)
+
+	if len(ops) != 3 {
+		t.Errorf("unexpected ops: %+v", err)
+	}
+	for _, o := range ops {
+		if !o.IsAdded {
+			t.Errorf("non-add op: %+v", o)
+		}
+	}
+
+	rules, err = org.DRRules(WithNamespace("general"))
+	a.NoError(err)
+	if len(rules) != 2 {
+		t.Errorf("general rules has: %+v", rules)
+	}
+	rules, err = org.DRRules(WithNamespace("managed"))
+	a.NoError(err)
+	if len(rules) != 1 {
+		t.Errorf("managed rules has: %+v", rules)
+	}
+
+	nc := `
+rules:
+  r1:
+    detect:
+      op: is
+      event: NEW_PROCESS
+      path: event/FILE_PATH
+      value: nope1
+    respond:
+      - action: report
+        name: t1
+  r2:
+    detect:
+      op: is
+      event: NEW_PROCESS
+      path: event/FILE_PATH
+      value: nope2
+    respond:
+      - action: report
+        name: t2
+  r3:
+    namespace: general
+    detect:
+      op: is
+      event: NEW_PROCESS
+      path: event/FILE_PATH
+      value: nope3
+    respond:
+      - action: report
+        name: t3
+`
+
+	c = OrgConfig{}
+	err = yaml.Unmarshal([]byte(nc), &c)
+	a.NoError(err)
+
+	ops, err = org.SyncPush(c, SyncOptions{
+		SyncDRRules: true,
+	})
+	a.NoError(err)
+
+	if len(ops) != 3 {
+		t.Errorf("unexpected ops: %+v", err)
+	}
+	nNew := 0
+	nOld := 0
+	for _, o := range ops {
+		if o.IsAdded {
+			nNew++
+		}
+		if !o.IsAdded && !o.IsRemoved {
+			nOld++
+		}
+	}
+	if nNew != 1 || nOld != 2 {
+		t.Errorf("unexpected ops: %v", ops)
+	}
+
+	rules, err = org.DRRules(WithNamespace("general"))
+	a.NoError(err)
+	if len(rules) != 3 {
+		t.Errorf("general rules has: %+v", rules)
+	}
+	rules, err = org.DRRules(WithNamespace("managed"))
+	a.NoError(err)
+	if len(rules) != 0 {
+		t.Errorf("managed rules has: %+v", rules)
+	}
+
+	err = org.DRDelRule("r1", WithNamespace("general"))
+	a.NoError(err)
+	err = org.DRDelRule("r2", WithNamespace("general"))
+	a.NoError(err)
+	err = org.DRDelRule("r3", WithNamespace("general"))
+	a.NoError(err)
 }

--- a/limacharlie/yaml.go
+++ b/limacharlie/yaml.go
@@ -1,0 +1,102 @@
+package limacharlie
+
+import (
+	"fmt"
+)
+
+func (d *Dict) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	out := map[string]interface{}{}
+	if err := unmarshal(&out); err != nil {
+		return err
+	}
+	if err := unmarshalCleanYAMLMap(out); err != nil {
+		return err
+	}
+	*d = out
+
+	return nil
+}
+
+func (l *List) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	out := []interface{}{}
+	if err := unmarshal(&out); err != nil {
+		return err
+	}
+	if err := unmarshalCleanYAMLList(out); err != nil {
+		return err
+	}
+	*l = out
+
+	return nil
+}
+
+func unmarshalCleanYAMLMap(out map[string]interface{}) error {
+	for k, v := range out {
+		switch val := v.(type) {
+		case map[interface{}]interface{}:
+			n, err := yamlMapToJsonMap(val)
+			if err != nil {
+				return err
+			}
+			out[k] = n
+			if err := unmarshalCleanYAMLMap(n); err != nil {
+				return err
+			}
+		case []interface{}:
+			if err := unmarshalCleanYAMLList(val); err != nil {
+				return err
+			}
+		default:
+			var err error
+			out[k], err = unmarshalCleanYAMLElement(val)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func yamlMapToJsonMap(m map[interface{}]interface{}) (map[string]interface{}, error) {
+	out := map[string]interface{}{}
+	for k, v := range m {
+		s, ok := k.(string)
+		if !ok {
+			return nil, fmt.Errorf("unsupported key type: %T", k)
+		}
+		out[s] = v
+	}
+	return out, nil
+}
+
+func unmarshalCleanYAMLList(out []interface{}) error {
+	for i, v := range out {
+		switch val := v.(type) {
+		case map[interface{}]interface{}:
+			n, err := yamlMapToJsonMap(val)
+			if err != nil {
+				return err
+			}
+			out[i] = n
+			if err := unmarshalCleanYAMLMap(n); err != nil {
+				return err
+			}
+		case []interface{}:
+			if err := unmarshalCleanYAMLList(val); err != nil {
+				return err
+			}
+		default:
+			var err error
+			out[i], err = unmarshalCleanYAMLElement(val)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func unmarshalCleanYAMLElement(out interface{}) (interface{}, error) {
+	// YAML handles integers vs floats properly already.
+	return out, nil
+}


### PR DESCRIPTION
- Sync/Configs mechanism for DR Rules only. We can expand to all types in the future (only Rules are needed for the Go lc-service).
- Added a JSON and YAML compat layer to help normalize the datatypes, taken from go-essentials.
- Permission check helper