### PR TITLE
Load client options first

### DIFF
--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -97,13 +97,13 @@ func isEmpty(s string) bool {
 // NewClientFromLoader initialize a client from options loaders.
 // Will return a valid client as soon as one loader returns valid requirements
 func NewClientFromLoader(inOpt ClientOptions, logger LCLogger, optsLoaders ...ClientOptionLoader) (*Client, error) {
+	if inOpt.validateMinimumRequirements() == nil && inOpt.validate() == nil {
+		return &Client{options: inOpt, logger: logger}, nil
+	}
+	
 	loaderCount := len(optsLoaders)
 	if loaderCount == 0 {
 		return nil, newLCError(lcErrClientNoOptionsLoader)
-	}
-
-	if inOpt.validateMinimumRequirements() == nil && inOpt.validate() == nil {
-		return &Client{options: inOpt, logger: logger}, nil
 	}
 
 	var opt ClientOptions

--- a/limacharlie/client_opts_loader.go
+++ b/limacharlie/client_opts_loader.go
@@ -9,6 +9,14 @@ type ClientOptionLoader interface {
 	Load(inOpt ClientOptions) (ClientOptions, error)
 }
 
+// NoopClientOptionLoader does not load any options
+type NoopClientOptionLoader struct{}
+
+// Load returns arguments passed
+func (l *NoopClientOptionLoader) Load(inOpt ClientOptions) (ClientOptions, error) {
+	return inOpt, nil
+}
+
 // EnvironmentClientOptionLoader loads options from environement variables
 type EnvironmentClientOptionLoader struct{}
 


### PR DESCRIPTION
## Description of the change

- Client will validate its options first before trying to load any
- Add noop client options loader

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

