### PR TITLE
Add Search message types & generic Request / Response message shapes

### DIFF
--- a/limacharlie/comms.go
+++ b/limacharlie/comms.go
@@ -84,23 +84,27 @@ type MessageCommandAck struct {
 }
 
 var CommsMessageTypes = struct {
-	Chat         string
-	Task         string
-	TaskResponse string
-	Error        string
-	CommandAck   string
-	Markdown     string
-	Json         string
-	Yaml         string
+	Chat           string
+	Search         string
+	SearchResponse string
+	Task           string
+	TaskResponse   string
+	Error          string
+	CommandAck     string
+	Markdown       string
+	Json           string
+	Yaml           string
 }{
-	Chat:         "chat",
-	Task:         "task",
-	TaskResponse: "task-response",
-	Error:        "error",
-	CommandAck:   "cmdack",
-	Markdown:     "markdown",
-	Json:         "json",
-	Yaml:         "yaml",
+	Chat:           "chat",
+	Search:         "search",
+	SearchResponse: "search-response",
+	Task:           "task",
+	TaskResponse:   "task-response",
+	Error:          "error",
+	CommandAck:     "cmdack",
+	Markdown:       "markdown",
+	Json:           "json",
+	Yaml:           "yaml",
 }
 
 var CommsCoreStatuses = struct {

--- a/limacharlie/comms.go
+++ b/limacharlie/comms.go
@@ -57,6 +57,14 @@ type MessageText struct {
 	Text string `json:"text"`
 }
 
+type MessageRequest struct {
+	Request map[string]interface{} `json:"request"`
+}
+
+type MessageResponse struct {
+	Response map[string]interface{} `json:"response"`
+}
+
 type MessageTasking struct {
 	Task    string   `json:"task"`
 	Sensors []string `json:"sensors"`


### PR DESCRIPTION
## Description of the change
* To provide feedback & custom formatted results, similar to `task`, adding `search` and `search-response` message types
* Add generic struct defs for `MessageRequest` and `MessageResponse` for pass-through of dicts

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
Relates to https://github.com/refractionPOINT/tracking/issues/714
