### PR TITLE
Clean up CommsMessageTypes & unnecessary Message structs

### DIFF
--- a/limacharlie/comms.go
+++ b/limacharlie/comms.go
@@ -57,20 +57,7 @@ type MessageText struct {
 	Text string `json:"text"`
 }
 
-type MessageRequest struct {
-	Request map[string]interface{} `json:"request"`
-}
-
 type MessageResponse struct {
-	Response map[string]interface{} `json:"response"`
-}
-
-type MessageTasking struct {
-	Task    string   `json:"task"`
-	Sensors []string `json:"sensors"`
-}
-
-type MessageTaskingResponse struct {
 	Response map[string]interface{} `json:"response"`
 }
 
@@ -92,27 +79,23 @@ type MessageCommandAck struct {
 }
 
 var CommsMessageTypes = struct {
-	Chat           string
-	Search         string
-	SearchResponse string
-	Task           string
-	TaskResponse   string
-	Error          string
-	CommandAck     string
-	Markdown       string
-	Json           string
-	Yaml           string
+	Chat       string
+	Search     string
+	Task       string
+	Error      string
+	CommandAck string
+	Markdown   string
+	Json       string
+	Yaml       string
 }{
-	Chat:           "chat",
-	Search:         "search",
-	SearchResponse: "search-response",
-	Task:           "task",
-	TaskResponse:   "task-response",
-	Error:          "error",
-	CommandAck:     "cmdack",
-	Markdown:       "markdown",
-	Json:           "json",
-	Yaml:           "yaml",
+	Chat:       "chat",
+	Search:     "search",
+	Task:       "task",
+	Error:      "error",
+	CommandAck: "cmdack",
+	Markdown:   "markdown",
+	Json:       "json",
+	Yaml:       "yaml",
 }
 
 var CommsCoreStatuses = struct {


### PR DESCRIPTION
## Description of the change
Last week we agreed to generalize the acking of commands, which removes the need for distinct `command` and `command-response` message types. 

Additionally, commands generally can pass-through their responses as a dict, so removing overly specific response Message structs in favour of a generic `MessageResponse`.

These contract alterations will be handled gracefully by the front-end here: https://github.com/refractionPOINT/web-app-frontend/pull/510

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
Relates to https://github.com/refractionPOINT/tracking/issues/723
