### PR TITLE
Add new default net policies to sync_test

### DIFF
--- a/limacharlie/sync_test.go
+++ b/limacharlie/sync_test.go
@@ -1020,6 +1020,8 @@ net-policy:
 	a.NoError(err)
 	expectedOps := sortSyncOps([]OrgSyncOperation{
 		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "allow-outbound", IsAdded: true},
+		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "conn-telemetry", IsAdded: true},
+		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "dns-telemetry", IsAdded: true},
 		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "custom_google", IsAdded: true},
 		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "sinkhole", IsAdded: true},
 	})
@@ -1071,6 +1073,8 @@ net-policy:
 	a.NoError(err)
 	expectedOps = sortSyncOps([]OrgSyncOperation{
 		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "default-allow-outbound", IsRemoved: true}, // that's a default
+		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "conn-telemetry", IsRemoved: true},         // also a default
+		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "dns-telemetry", IsRemoved: true},          // believe it or not, also default
 		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "allow-outbound", IsRemoved: true},
 		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "custom_google", IsRemoved: true},
 		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "sinkhole"},

--- a/limacharlie/sync_test.go
+++ b/limacharlie/sync_test.go
@@ -1020,8 +1020,6 @@ net-policy:
 	a.NoError(err)
 	expectedOps := sortSyncOps([]OrgSyncOperation{
 		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "allow-outbound", IsAdded: true},
-		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "conn-telemetry", IsAdded: true},
-		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "dns-telemetry", IsAdded: true},
 		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "custom_google", IsAdded: true},
 		{ElementType: OrgSyncOperationElementType.NetPolicy, ElementName: "sinkhole", IsAdded: true},
 	})
@@ -1097,7 +1095,7 @@ net-policy:
 	a.Equal(expectedOps, sortSyncOps(ops))
 	netPolicies, err = org.NetPolicies()
 	a.NoError(err)
-	a.Equal(netPoliciesCountStart+1, len(netPolicies))
+	a.Equal(netPoliciesCountStart-1, len(netPolicies))
 
 	for name, orgPolicy := range forceOrgConfig.NetPolicies {
 		policy, found := netPolicies[name]


### PR DESCRIPTION
## Description of the change
Added `conn-telemetry` and `dns-telemetry` to the tests

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

