### PR TITLE
Remove unused comms message types

### DIFF
--- a/limacharlie/comms.go
+++ b/limacharlie/comms.go
@@ -80,8 +80,6 @@ type MessageCommandAck struct {
 
 var CommsMessageTypes = struct {
 	Chat       string
-	Search     string
-	Task       string
 	Error      string
 	CommandAck string
 	Markdown   string
@@ -89,8 +87,6 @@ var CommsMessageTypes = struct {
 	Yaml       string
 }{
 	Chat:       "chat",
-	Search:     "search",
-	Task:       "task",
 	Error:      "error",
 	CommandAck: "cmdack",
 	Markdown:   "markdown",


### PR DESCRIPTION
## Description of the change

Only leave generic message types in the sdk

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Related to https://github.com/refractionPOINT/tracking/issues/744
