### PR TITLE
Res sync errors not reported.

### DIFF
--- a/limacharlie/sync.go
+++ b/limacharlie/sync.go
@@ -1611,7 +1611,7 @@ func (org Organization) syncResources(resources orgSyncResources, options SyncOp
 					continue
 				}
 				if err := org.Comms().o.ResourceSubscribe(resName, resCat); err != nil {
-					return ops, nil
+					return ops, err
 				}
 				ops = append(ops, OrgSyncOperation{
 					ElementType: OrgSyncOperationElementType.Resource,
@@ -1641,7 +1641,7 @@ func (org Organization) syncResources(resources orgSyncResources, options SyncOp
 				continue
 			}
 			if err := org.Comms().o.ResourceSubscribe(resName, resCat); err != nil {
-				return ops, nil
+				return ops, err
 			}
 			ops = append(ops, OrgSyncOperation{
 				ElementType: OrgSyncOperationElementType.Resource,


### PR DESCRIPTION
## Description of the change

We were not reporting all Resource sync errors.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


