### PR TITLE
Adding support for the perms param for JWTs.

### DIFF
--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -46,6 +46,7 @@ type ClientOptions struct {
 	UID           string
 	JWT           string
 	Environment   string
+	Permissions   []string
 	JWTExpiryTime time.Duration
 }
 
@@ -171,6 +172,9 @@ func (c *Client) RefreshJWT(expiry time.Duration) (string, error) {
 	}
 	if expiry != 0 {
 		authData.Set("expiry", fmt.Sprintf("%d", int64(expiry.Seconds())))
+	}
+	if c.options.Permissions != nil {
+		authData.Set("perms", strings.Join(c.options.Permissions, ","))
 	}
 
 	resp, err := http.PostForm(getJWTURL, authData)


### PR DESCRIPTION
## Description of the change

Adding support for the `perms` option when getting a JWT. The JWT generated will only contain the specified permissions.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


