### PR TITLE
Fix hive json marshal

### DIFF
--- a/limacharlie/hive.go
+++ b/limacharlie/hive.go
@@ -240,6 +240,11 @@ func (h *HiveClient) Remove(args HiveArgs) (interface{}, error) {
 }
 
 func (hsd *HiveData) Equals(cData HiveData) (bool, error) {
+	err := encodeDecodeHiveData(&hsd.Data)
+	if err != nil {
+		return false, err
+	}
+
 	currentData, err := json.Marshal(hsd.Data)
 	if err != nil {
 		return false, err

--- a/limacharlie/sync.go
+++ b/limacharlie/sync.go
@@ -878,7 +878,7 @@ func (org Organization) SyncPush(conf OrgConfig, options SyncOptions) ([]OrgSync
 		newOps, err := org.syncHive(conf.Hives, options)
 		ops = append(ops, newOps...)
 		if err != nil {
-			return ops, fmt.Errorf("synchHives: %+v ", err)
+			return ops, fmt.Errorf("syncHives: %+v ", err)
 		}
 	}
 

--- a/limacharlie/sync.go
+++ b/limacharlie/sync.go
@@ -40,7 +40,7 @@ type SyncOptions struct {
 	SyncArtifacts   bool            `json:"sync_artifacts"`
 	SyncNetPolicies bool            `json:"sync_net_policies"`
 	SyncOrgValues   bool            `json:"sync_org_values"`
-	SyncHives       map[string]bool `json:"sync_hive"`
+	SyncHives       map[string]bool `json:"sync_hives"`
 
 	IncludeLoader IncludeLoaderCB `json:"-"`
 }

--- a/limacharlie/sync_hive.go
+++ b/limacharlie/sync_hive.go
@@ -2,6 +2,7 @@ package limacharlie
 
 import (
 	"encoding/json"
+	"gopkg.in/yaml.v3"
 	"sync"
 )
 
@@ -182,6 +183,11 @@ func (org Organization) fetchHiveConfigData(args HiveArgs) (HiveConfigData, erro
 func (org Organization) updateHiveConfigData(ha HiveArgs, hd HiveData) error {
 	hiveClient := NewHiveClient(&org)
 
+	err := encodeDecodeHiveData(&hd.Data)
+	if err != nil {
+		return err
+	}
+
 	data, err := json.Marshal(hd.Data)
 	if err != nil {
 		return err
@@ -208,6 +214,11 @@ func (org Organization) updateHiveConfigData(ha HiveArgs, hd HiveData) error {
 
 func (org Organization) addHiveConfigData(ha HiveArgs, hd HiveData) error {
 	hiveClient := NewHiveClient(&org)
+
+	err := encodeDecodeHiveData(&hd.Data)
+	if err != nil {
+		return err
+	}
 
 	mData, err := json.Marshal(hd.Data)
 	if err != nil {
@@ -243,4 +254,14 @@ func (org Organization) removeHiveConfigData(args HiveArgs) error {
 	}
 
 	return nil
+}
+
+// encodeDecodeHiveData ensures that any passed hiveData is properly
+// encoded using YamlV3 to handle json type of map[interface {}]interface{}
+func encodeDecodeHiveData(hd *map[string]interface{}) error {
+	out, err := yaml.Marshal(hd)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(out, &hd)
 }

--- a/limacharlie/sync_hive_test.go
+++ b/limacharlie/sync_hive_test.go
@@ -2,7 +2,7 @@ package limacharlie
 
 import (
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v2"
 	"os"
 	"strings"
 	"testing"


### PR DESCRIPTION
## Description of the change

> Fixes issue of json marshaling of hive data. When attempting to pass json data from python SDK I was getting the following error: {'json: unsupported type: map[interface {}]interface {} '} I believe this stemmed from the way that python was encoding json data. I was able to reproduce in GO by using yamlV2 lib and calling yaml.Unmarshal on yaml string. Go SDK will now run marshal and unmarshal with  YamlV3 to ensure we are able to handle map[interface {}] interface{} decoding. 

## Type of change
- [ x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Describe multi-tenancy segmentation

