### PR TITLE
Fix equal compare for null and empty tags

### DIFF
--- a/limacharlie/hive.go
+++ b/limacharlie/hive.go
@@ -240,8 +240,6 @@ func (h *HiveClient) Remove(args HiveArgs) (interface{}, error) {
 }
 
 func (hsd *HiveData) Equals(cData HiveData) (bool, error) {
-	fmt.Println("inside of equals ")
-
 	err := encodeDecodeHiveData(&hsd.Data)
 	if err != nil {
 		return false, err

--- a/limacharlie/hive.go
+++ b/limacharlie/hive.go
@@ -240,6 +240,8 @@ func (h *HiveClient) Remove(args HiveArgs) (interface{}, error) {
 }
 
 func (hsd *HiveData) Equals(cData HiveData) (bool, error) {
+	fmt.Println("inside of equals ")
+
 	err := encodeDecodeHiveData(&hsd.Data)
 	if err != nil {
 		return false, err
@@ -264,11 +266,17 @@ func (hsd *HiveData) Equals(cData HiveData) (bool, error) {
 		return false, nil
 	}
 
+	if len(hsd.UsrMtd.Tags) == 0 {
+		hsd.UsrMtd.Tags = nil
+	}
 	newUsrMTd, err := json.Marshal(hsd.UsrMtd)
 	if err != nil {
 		return false, err
 	}
 
+	if len(cData.UsrMtd.Tags) == 0 {
+		cData.UsrMtd.Tags = nil
+	}
 	curUsrMtd, err := json.Marshal(cData.UsrMtd)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## Description of the change

> UsrMtd tags were showing as not equal if empty array is passed in yaml

## Type of change
- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Describe multi-tenancy segmentation

