### PR TITLE
Fix yaml bool evaluated as empty string

### DIFF
--- a/limacharlie/sync_test.go
+++ b/limacharlie/sync_test.go
@@ -26,7 +26,7 @@ func TestSyncPushResources(t *testing.T) {
 	org := getTestOrgFromEnv(a)
 
 	resetResource(org)
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 	resourcesBase, err := org.Resources()
 
 	a.NoError(err)


### PR DESCRIPTION


## Handle yaml bool evaluated as empty string for outconfig yaml

> Description here

## Type of change
- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Describe multi-tenancy segmentation

