### PR TITLE
Refactor Hives to be the core of the info needed.

### DIFF
--- a/limacharlie/hive.go
+++ b/limacharlie/hive.go
@@ -25,7 +25,7 @@ type HiveArgs struct {
 type HiveConfigData map[string]HiveData
 
 type HiveData struct {
-	Data   map[string]interface{} `json:"data" yaml:"data"`
+	Data   map[string]interface{} `json:"data" yaml:"data,omitempty"`
 	SysMtd SysMtd                 `json:"sys_mtd" yaml:"sys_mtd"`
 	UsrMtd UsrMtd                 `json:"usr_mtd" yaml:"usr_mtd"`
 }
@@ -249,7 +249,7 @@ func (hsd *HiveData) Equals(cData HiveData) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if string(newData) == "{}" || string(newData) == "null" {
+	if string(newData) == "null" {
 		newData = nil
 	}
 
@@ -257,7 +257,7 @@ func (hsd *HiveData) Equals(cData HiveData) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if string(currentData) == "{}" || string(currentData) == "null" {
+	if string(currentData) == "null" {
 		currentData = nil
 	}
 	if string(currentData) != string(newData) {

--- a/limacharlie/sync.go
+++ b/limacharlie/sync.go
@@ -191,7 +191,7 @@ type orgSyncExfilRules = ExfilRulesType
 type orgSyncArtifacts = map[ArtifactRuleName]OrgSyncArtifactRule
 type orgSyncNetPolicies = NetPoliciesByName
 type orgSyncOrgValues = map[OrgValueName]OrgValue
-type orgSyncHives = map[HiveName]map[HiveKey]HiveData
+type orgSyncHives = map[HiveName]map[HiveKey]SyncHiveData
 
 type OrgConfig struct {
 	Version     int                   `json:"version" yaml:"version"`

--- a/limacharlie/sync_hive.go
+++ b/limacharlie/sync_hive.go
@@ -319,3 +319,18 @@ func (hsd *SyncHiveData) Equals(cData SyncHiveData) (bool, error) {
 
 	return true, nil
 }
+
+func (hcd HiveConfigData) AsSyncConfigData() SyncHiveConfigData {
+	out := SyncHiveConfigData{}
+	for k, v := range hcd {
+		out[k] = v.AsSyncData()
+	}
+	return out
+}
+
+func (hd HiveData) AsSyncData() SyncHiveData {
+	return SyncHiveData{
+		Data:   hd.Data,
+		UsrMtd: hd.UsrMtd,
+	}
+}

--- a/limacharlie/sync_hive_test.go
+++ b/limacharlie/sync_hive_test.go
@@ -218,9 +218,9 @@ func TestHiveNoUpdate(t *testing.T) {
 	}
 
 	orgConfig := OrgConfig{}
-	configHive := map[HiveName]map[HiveKey]HiveData{
-		"cloud_sensor": hiveSensorData,
-		"fp":           hiveFpData,
+	configHive := map[HiveName]map[HiveKey]SyncHiveData{
+		"cloud_sensor": hiveSensorData.AsSyncConfigData(),
+		"fp":           hiveFpData.AsSyncConfigData(),
 	}
 	orgConfig.Hives = configHive
 

--- a/limacharlie/sync_hive_test.go
+++ b/limacharlie/sync_hive_test.go
@@ -98,7 +98,7 @@ func TestHiveAddData(t *testing.T) {
 		t.Errorf("hive sync push failure TestAddData err: %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("error no orgOps testAddData")
 		return
 	}
@@ -115,7 +115,7 @@ func TestHiveAddData(t *testing.T) {
 		t.Errorf("error hive sync push %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("error no orgOps testAddData")
 		return
 	}
@@ -169,7 +169,7 @@ func TestHiveDataUpdate(t *testing.T) {
 		t.Errorf("error hive sync push %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("error no orgOps testDataUpdate")
 		return
 	}
@@ -184,7 +184,7 @@ func TestHiveDataUpdate(t *testing.T) {
 		t.Errorf("error hive sync push %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("error no orgOps for update ")
 	}
 	expectedOps = sortSyncOps([]OrgSyncOperation{
@@ -229,7 +229,7 @@ func TestHiveNoUpdate(t *testing.T) {
 		t.Errorf("hive sync push testNoUpdate err: %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("error no orgOps for testNoUpdate")
 		return
 	}
@@ -280,7 +280,7 @@ func TestHiveNoUpdate(t *testing.T) {
 		t.Errorf("error hive sync push %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("error no orgOps for update ")
 		return
 	}
@@ -366,7 +366,7 @@ func TestHiveUsrMtdUpdate(t *testing.T) {
 		t.Errorf("hive sync push testUsrMtdUpdate err: %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("error no orgOps for update ")
 		return
 	}
@@ -381,7 +381,7 @@ func TestHiveUsrMtdUpdate(t *testing.T) {
 		t.Errorf("error hive sync push %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("error no orgOps for update ")
 		return
 	}
@@ -473,7 +473,7 @@ func TestHiveMultipleDataUpdates(t *testing.T) {
 		t.Errorf("error hive sync push testMultipleDataUpdates %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("fith test failed no org opts present ")
 		return
 	}
@@ -490,7 +490,7 @@ func TestHiveMultipleDataUpdates(t *testing.T) {
 		t.Errorf("error hive sync push %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("fith test failed no org opts present ")
 	}
 	expectedOps = sortSyncOps([]OrgSyncOperation{
@@ -582,7 +582,7 @@ func TestHiveMultipleUsrMtdUpdate(t *testing.T) {
 		t.Errorf("error  testMultipleUsrMtdUpdate hive sync push %+v ", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("testMultipleUsrMtdUpdate failed no org opts present ")
 		return
 	}
@@ -601,7 +601,7 @@ func TestHiveMultipleUsrMtdUpdate(t *testing.T) {
 		t.Errorf("error testMultipleUsrMtdUpdate hive sync push %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("testMultipleUsrMtdUpdate failed no org opts present ")
 		return
 	}
@@ -636,29 +636,29 @@ func TestHiveRemove(t *testing.T) {
 		return
 	}
 
-	for k, _ := range hiveSensorData {
+	for k := range hiveSensorData {
 		if k == s3TestHiveKey || k == office365TestHiveKey {
 			delete(hiveSensorData, k)
 		}
 	}
 
-	for k, _ := range hiveFpData {
+	for k := range hiveFpData {
 		if k == fpTestHiveKey {
 			delete(hiveFpData, k)
 		}
 	}
 
 	orgConfig := OrgConfig{}
-	orgConfig.Hives = map[HiveName]map[HiveKey]HiveData{
-		"cloud_sensor": hiveSensorData,
-		"fp":           hiveFpData,
+	orgConfig.Hives = map[HiveName]map[HiveKey]SyncHiveData{
+		"cloud_sensor": hiveSensorData.AsSyncConfigData(),
+		"fp":           hiveFpData.AsSyncConfigData(),
 	}
 	orgOps, err := org.SyncPush(orgConfig, SyncOptions{IsDryRun: true, IsForce: true, SyncHives: map[string]bool{"cloud_sensor": true, "fp": true}})
 	if err != nil {
 		t.Errorf("error TestRemove hive sync push %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("testRemove failed no org opts present ")
 		return
 	}
@@ -708,7 +708,7 @@ func TestHiveRemove(t *testing.T) {
 		t.Errorf("error hive sync push %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("seventh test failed no org opts present ")
 	}
 
@@ -802,7 +802,7 @@ hives:
 		t.Errorf("error TestRemove hive sync push %+v", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("testRemove failed no org opts present ")
 		return
 	}
@@ -819,7 +819,7 @@ hives:
 		t.Errorf("error TestRemove hive sync push %+v \n", err)
 		return
 	}
-	if orgOps == nil || len(orgOps) == 0 {
+	if len(orgOps) == 0 {
 		t.Errorf("testRemove failed no org opts present ")
 		return
 	}
@@ -978,7 +978,7 @@ func TestHiveMerge(t *testing.T) {
 
 	// process merge
 	newOrgConfig := orgConfigOne.Merge(orgConfigTwo)
-	for n, _ := range newOrgConfig.Hives {
+	for n := range newOrgConfig.Hives {
 		for k, data := range newOrgConfig.Hives[n] {
 			if k == s3TestHiveKey || k == office365TestHiveKey {
 				equal, err := data.Equals(orgConfigTwo.Hives[n][k])


### PR DESCRIPTION
## Description of the change

Remove the sys_mtd from the hive sync since it's not needed for infra as code.
Make the Data in YAML "omitempty" to be more clear about when data is not available, otherwise YAML defaults it to `{}` as opposed to JSON which uses `null`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


