### PR TITLE
Hive data as form, not query.

### DIFF
--- a/limacharlie/hive.go
+++ b/limacharlie/hive.go
@@ -158,7 +158,7 @@ func (h *HiveClient) Add(args HiveArgs) (*HiveResp, error) {
 	}
 
 	var hiveResp HiveResp
-	req := makeDefaultRequest(&hiveResp).withQueryData(reqDict)
+	req := makeDefaultRequest(&hiveResp).withFormData(reqDict)
 	if err := h.Organization.client.reliableRequest(http.MethodPost,
 		fmt.Sprintf("hive/%s/%s/%s/%s", args.HiveName, args.PartitionKey, args.Key, target), req); err != nil {
 		return nil, err
@@ -220,7 +220,7 @@ func (h *HiveClient) Update(args HiveArgs) (interface{}, error) {
 	}
 
 	var updateResp HiveResp
-	req := makeDefaultRequest(&updateResp).withQueryData(reqData)
+	req := makeDefaultRequest(&updateResp).withFormData(reqData)
 	if err := h.Organization.client.reliableRequest(http.MethodPost,
 		fmt.Sprintf("hive/%s/%s/%s/%s", args.HiveName, args.PartitionKey, args.Key, target), req); err != nil {
 		return nil, err


### PR DESCRIPTION
## Description of the change

Transmit Hive changes as Form data, not query strings.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

