### PR TITLE
Make the hive args avoid useless marshaling round-trips.

### DIFF
--- a/limacharlie/hive.go
+++ b/limacharlie/hive.go
@@ -125,7 +125,7 @@ func (h *HiveClient) Add(args HiveArgs) (*HiveResp, error) {
 	}
 
 	target := "mtd" // if no data set default to target type mtd
-	if args.Data != nil {
+	if len(args.Data) != 0 {
 		target = "data"
 	}
 
@@ -167,7 +167,7 @@ func (h *HiveClient) Update(args HiveArgs) (interface{}, error) {
 	target := "mtd" // if no data set default to target type mtd
 	existing := &HiveData{}
 	var err error
-	if args.Data != nil {
+	if len(args.Data) != 0 {
 		target = "data"
 		existing, err = h.Get(args)
 		if err != nil {

--- a/limacharlie/hive_test.go
+++ b/limacharlie/hive_test.go
@@ -1,12 +1,14 @@
 package limacharlie
 
 import (
-	"github.com/stretchr/testify/assert"
+	"encoding/json"
 	"math/rand"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var testHiveClient *HiveClient
@@ -55,7 +57,10 @@ func hiveAddTest(t *testing.T) {
 	jsonString = strings.ReplaceAll(jsonString, "oid-input", os.Getenv("_OID"))
 
 	testKey = "hive-test-" + randSeq(8) // ran key to keep track of newly created hive data record
-	data := []byte(jsonString)
+	data := Dict{}
+	if err := json.Unmarshal([]byte(jsonString), &data); err != nil {
+		panic(err)
+	}
 	hiveResp, err := testHiveClient.Add(HiveArgs{
 		HiveName:     "cloud_sensor",
 		PartitionKey: os.Getenv("_OID"),
@@ -190,7 +195,10 @@ func hiveUpdate(t *testing.T) {
 				}`
 	jsonString = strings.ReplaceAll(jsonString, "oid-input", os.Getenv("_OID"))
 
-	data := []byte(jsonString)
+	data := Dict{}
+	if err := json.Unmarshal([]byte(jsonString), &data); err != nil {
+		panic(err)
+	}
 	_, err := testHiveClient.Update(HiveArgs{
 		HiveName:     "cloud_sensor",
 		PartitionKey: os.Getenv("_OID"),

--- a/limacharlie/sync_hive.go
+++ b/limacharlie/sync_hive.go
@@ -194,10 +194,6 @@ func (org Organization) updateHiveConfigData(ha HiveArgs, hd SyncHiveData) error
 		return err
 	}
 
-	data, err := json.Marshal(hd.Data)
-	if err != nil {
-		return err
-	}
 	enabled := hd.UsrMtd.Enabled
 	expiry := hd.UsrMtd.Expiry
 	Tags := hd.UsrMtd.Tags
@@ -205,7 +201,7 @@ func (org Organization) updateHiveConfigData(ha HiveArgs, hd SyncHiveData) error
 		Key:          ha.Key,
 		PartitionKey: ha.PartitionKey,
 		HiveName:     ha.HiveName,
-		Data:         data,
+		Data:         hd.Data,
 		Enabled:      &enabled,
 		Expiry:       &expiry,
 		Tags:         Tags,
@@ -226,11 +222,6 @@ func (org Organization) addHiveConfigData(ha HiveArgs, hd SyncHiveData) error {
 		return err
 	}
 
-	mData, err := json.Marshal(hd.Data)
-	if err != nil {
-		return err
-	}
-
 	enabled := hd.UsrMtd.Enabled
 	expiry := hd.UsrMtd.Expiry
 	Tags := hd.UsrMtd.Tags
@@ -238,7 +229,7 @@ func (org Organization) addHiveConfigData(ha HiveArgs, hd SyncHiveData) error {
 		Key:          ha.Key,
 		PartitionKey: ha.PartitionKey,
 		HiveName:     ha.HiveName,
-		Data:         mData,
+		Data:         hd.Data,
 		Enabled:      &enabled,
 		Expiry:       &expiry,
 		Tags:         Tags,


### PR DESCRIPTION
## Description of the change

Move the Hive interface to use Dict instead of serialized JSON to avoid unneeded marshalling round-trips.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

