### PR TITLE
feat: add method to fetch historical detections for organizations

### DIFF
--- a/limacharlie/retention.go
+++ b/limacharlie/retention.go
@@ -112,13 +112,7 @@ func (org Organization) HistoricalDetections(detectionReq HistoricalDetectionsRe
 	}
 
 	q := makeDefaultRequest(&results)
-	q = q.withQueryData(Dict{
-		"cat":    detectionReq.Cat,
-		"cursor": detectionReq.Cursor,
-		"start":  detectionReq.Start,
-		"end":    detectionReq.End,
-		"limit":  detectionReq.Limit,
-	})
+	q = q.withQueryData(detectionReq)
 
 	if err := org.client.reliableRequest(http.MethodGet, fmt.Sprintf("insight/%s/detections", org.client.options.OID), q); err != nil {
 		return results, err
@@ -148,7 +142,7 @@ type DetectMetadata struct {
 type Detects struct {
 	Author    string         `json:"author"`
 	Cat       string         `json:"cat"`
-	Detect    Detect         `json:"detect"`
+	Detect    Dict         `json:"detect"`
 	DetectID  string         `json:"detect_id"`
 	DetectMtd DetectMetadata `json:"detect_mtd"`
 	Link      string         `json:"link"`
@@ -158,33 +152,3 @@ type Detects struct {
 	Ts        int64          `json:"ts"`
 }
 
-const NewProcessEventType = "NEW_PROCESS"
-
-type NewProcessEvent struct {
-	BaseAddress     int64  `json:"BASE_ADDRESS"`
-	CommandLine     string `json:"COMMAND_LINE"`
-	FileIsSigned    int    `json:"FILE_IS_SIGNED"`
-	FilePath        string `json:"FILE_PATH"`
-	Hash            string `json:"HASH"`
-	MemoryUsage     int    `json:"MEMORY_USAGE"`
-	Parent          Parent `json:"PARENT"`
-	ParentProcessID int    `json:"PARENT_PROCESS_ID"`
-	ProcessID       int    `json:"PROCESS_ID"`
-	Threads         int    `json:"THREADS"`
-	UserName        string `json:"USER_NAME"`
-}
-
-type Parent struct {
-	CommandLine     string `json:"COMMAND_LINE"`
-	FileIsSigned    int    `json:"FILE_IS_SIGNED"`
-	FilePath        string `json:"FILE_PATH"`
-	Hash            string `json:"HASH"`
-	MemoryUsage     int    `json:"MEMORY_USAGE"`
-	ParentAtom      string `json:"PARENT_ATOM"`
-	ParentProcessID int    `json:"PARENT_PROCESS_ID"`
-	ProcessID       int    `json:"PROCESS_ID"`
-	ThisAtom        string `json:"THIS_ATOM"`
-	Threads         int    `json:"THREADS"`
-	Timestamp       int64  `json:"TIMESTAMP"`
-	UserName        string `json:"USER_NAME"`
-}

--- a/limacharlie/retention.go
+++ b/limacharlie/retention.go
@@ -89,3 +89,102 @@ func (org *Organization) EventByAtom(sensorID, atom string) (EventContainer, err
 	err := org.client.reliableRequest(http.MethodGet, fmt.Sprintf("insight/%s/%s/%s", org.client.options.OID, sensorID, atom), q)
 	return event, err
 }
+
+type HistoricalDetectionsRequest struct {
+	// Cat is the category of the detections to fetch
+	Cat string `json:"cat"`
+	// Cursor is optional for paginated access, set to '-' for first query
+	Cursor string `json:"cursor"`
+	// Start is the required timestamp in seconds where to stop fetching detections
+	Start int `json:"start"`
+	// End is the required timestamp in seconds where to stop fetching detections
+	End int `json:"end"`
+	// Limit maximum number of detections to return
+	Limit int `json:"limit"`
+}
+
+func (org Organization) HistoricalDetections(detectionReq HistoricalDetectionsRequest) (HistoricalDetectionsResponse, error) {
+
+	var results HistoricalDetectionsResponse
+
+	if detectionReq.Cursor == "" {
+		detectionReq.Cursor = "-"
+	}
+
+	q := makeDefaultRequest(&results)
+	q = q.withQueryData(Dict{
+		"cat":    detectionReq.Cat,
+		"cursor": detectionReq.Cursor,
+		"start":  detectionReq.Start,
+		"end":    detectionReq.End,
+		"limit":  detectionReq.Limit,
+	})
+
+	if err := org.client.reliableRequest(http.MethodGet, fmt.Sprintf("insight/%s/detections", org.client.options.OID), q); err != nil {
+		return results, err
+	}
+
+	return results, nil
+}
+
+type HistoricalDetectionsResponse struct {
+	Detects    []Detects `json:"detects"`
+	NextCursor string    `json:"next_cursor"`
+}
+
+type Detect struct {
+	Event   Event   `json:"event"`
+	Routing Routing `json:"routing"`
+}
+type DetectMetadata struct {
+	Author         string   `json:"author"`
+	Description    string   `json:"description"`
+	Falsepositives []string `json:"falsepositives"`
+	Level          string   `json:"level"`
+	References     []string `json:"references"`
+	Tags           []string `json:"tags"`
+}
+
+type Detects struct {
+	Author    string         `json:"author"`
+	Cat       string         `json:"cat"`
+	Detect    Detect         `json:"detect"`
+	DetectID  string         `json:"detect_id"`
+	DetectMtd DetectMetadata `json:"detect_mtd"`
+	Link      string         `json:"link"`
+	Namespace string         `json:"namespace"`
+	Routing   Routing        `json:"routing"`
+	Source    string         `json:"source"`
+	Ts        int64          `json:"ts"`
+}
+
+const NewProcessEventType = "NEW_PROCESS"
+
+type NewProcessEvent struct {
+	BaseAddress     int64  `json:"BASE_ADDRESS"`
+	CommandLine     string `json:"COMMAND_LINE"`
+	FileIsSigned    int    `json:"FILE_IS_SIGNED"`
+	FilePath        string `json:"FILE_PATH"`
+	Hash            string `json:"HASH"`
+	MemoryUsage     int    `json:"MEMORY_USAGE"`
+	Parent          Parent `json:"PARENT"`
+	ParentProcessID int    `json:"PARENT_PROCESS_ID"`
+	ProcessID       int    `json:"PROCESS_ID"`
+	Threads         int    `json:"THREADS"`
+	UserName        string `json:"USER_NAME"`
+}
+
+type Parent struct {
+	CommandLine     string `json:"COMMAND_LINE"`
+	FileIsSigned    int    `json:"FILE_IS_SIGNED"`
+	FilePath        string `json:"FILE_PATH"`
+	Hash            string `json:"HASH"`
+	MemoryUsage     int    `json:"MEMORY_USAGE"`
+	ParentAtom      string `json:"PARENT_ATOM"`
+	ParentProcessID int    `json:"PARENT_PROCESS_ID"`
+	ProcessID       int    `json:"PROCESS_ID"`
+	ThisAtom        string `json:"THIS_ATOM"`
+	Threads         int    `json:"THREADS"`
+	Timestamp       int64  `json:"TIMESTAMP"`
+	UserName        string `json:"USER_NAME"`
+}


### PR DESCRIPTION
## Description of the change

Add method `GetHistoricalDetections` to fetch list of detections from `/insight/{oid}/detections`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Describe multi-tenancy segmentation

- By OID
