### PR TITLE
Avoid returning an error from JWT refresh when no api key is present.

### DIFF
--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -236,6 +236,11 @@ func (c *Client) reliableRequest(verb string, path string, request restRequest) 
 		if statusCode == http.StatusUnauthorized {
 			// Unauthorized, the JWT may have expired, refresh
 			// it and retry.
+			// If there is no API Key configured, provide the
+			// previous error instead of the refresh.
+			if c.options.APIKey == "" {
+				return err
+			}
 			if _, err = c.RefreshJWT(c.options.JWTExpiryTime); err != nil {
 				// If we cannot get a new JWT there is no point in
 				// retrying with bad creds.


### PR DESCRIPTION
## Description of the change

Return a more useful error than a no-api-key when no api key is configured to start with.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
