### PR TITLE
Extension API does not use b64.

### DIFF
--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -280,10 +280,9 @@ func (c *Client) extensionRequest(responseData interface{}, extensionName string
 	if err != nil {
 		return err
 	}
-	encodedData := base64.StdEncoding.EncodeToString(bytes)
 	reqData := Dict{
 		"oid":    c.options.OID,
-		"data":   encodedData,
+		"data":   string(bytes),
 		"action": action,
 	}
 	if isImpersonate {


### PR DESCRIPTION
## Description of the change

Slightly different API for extensions.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

