### PR TITLE
Missing Output field names.

### DIFF
--- a/limacharlie/output.go
+++ b/limacharlie/output.go
@@ -144,6 +144,8 @@ type OutputConfig struct {
 	Color             string `json:"color,omitempty" yaml:"color,omitempty"`
 	CloudID           string `json:"cloud_id,omitempty" yaml:"cloud_id,omitempty"`
 	Index             string `json:"index,omitempty" yaml:"index,omitempty"`
+	Addresses         string `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+	APIKey            string `json:"api_key,omitempty" yaml:"api_key,omitempty"`
 }
 
 func (o OutputConfig) Equals(other OutputConfig) bool {


### PR DESCRIPTION
## Description of the change

Some output field names were missing for elastic and opensearch.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

