### PR TITLE
Parallelize the upload of Artifacts.

### DIFF
--- a/limacharlie/artifact.go
+++ b/limacharlie/artifact.go
@@ -45,7 +45,7 @@ type artifactExportResp struct {
 	Export  string `json:"export,omitempty"`
 }
 
-const MAX_UPLOAD_PART_SIZE = 1024 * 1024
+var maxUploadFilePartSize = int64(1024 * 1024)
 
 func (org Organization) artifact(responseData interface{}, action string, req Dict) error {
 	reqData := req
@@ -143,7 +143,7 @@ func (org Organization) UploadArtifact(data io.Reader, size int64, hint string, 
 	for {
 		// Read from the data in chunks of MAX_UPLOAD_PART_SIZE so we can
 		// upload in parts if the file is too big.
-		chunk := make([]byte, MAX_UPLOAD_PART_SIZE)
+		chunk := make([]byte, maxUploadFilePartSize)
 		n, err := data.Read(chunk)
 		if err != nil && err != io.EOF {
 			return err
@@ -158,7 +158,7 @@ func (org Organization) UploadArtifact(data io.Reader, size int64, hint string, 
 		if endOffset > size {
 			return fmt.Errorf("got more data (%d bytes) than expected (%d bytes)", endOffset, size)
 		}
-		if size <= MAX_UPLOAD_PART_SIZE {
+		if size <= maxUploadFilePartSize {
 			// If the file is small enough, we can upload it in one go.
 		} else if endOffset != size {
 			headers["lc-part"] = fmt.Sprintf("%d", partId)

--- a/limacharlie/artifact_test.go
+++ b/limacharlie/artifact_test.go
@@ -16,8 +16,12 @@ func TestArtifactUpload(t *testing.T) {
 	ingestionKey := resp["key"]
 
 	testName := uuid.NewString()
-	testData := []byte("thisisatestartifact")
-	a.NoError(org.CreateArtifactFromBytes(testName, testData, "txt", uuid.New().String(), 30, ingestionKey.(string)))
+	testData := []byte("thisisatestartifactthisisatestartifactthisisatestartifactthisisatestartifactthisisatestartifactthisisatestartifact")
+
+	// Tweak the artifact part size to make sure we test the multipart upload.
+	maxUploadFilePartSize = 15
+
+	a.NoError(org.CreateArtifactFromBytes(testName, testData, "txt", uuid.New().String(), 1, ingestionKey.(string)))
 
 	// delete ingestion key
 	resp, _ = org.DelIngestionKeys("__test_key")

--- a/limacharlie/artifact_test.go
+++ b/limacharlie/artifact_test.go
@@ -16,8 +16,8 @@ func TestArtifactUpload(t *testing.T) {
 	ingestionKey := resp["key"]
 
 	testName := uuid.NewString()
-	testData := "thisisatestartifact"
-	a.NoError(org.CreateArtifact(testName, testData, "txt", uuid.New().String(), 30, ingestionKey.(string)))
+	testData := []byte("thisisatestartifact")
+	a.NoError(org.CreateArtifactFromBytes(testName, testData, "txt", uuid.New().String(), 30, ingestionKey.(string)))
 
 	// delete ingestion key
 	resp, _ = org.DelIngestionKeys("__test_key")


### PR DESCRIPTION
## Description of the change

Move code to support accelerate the upload of Artifacts by sending chunks in parallel.
Not actually configured to do it yet as we have some dependencies in the backend on upload order.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

