### PR TITLE
Enable parallel artifact upload and test.

### DIFF
--- a/limacharlie/artifact.go
+++ b/limacharlie/artifact.go
@@ -230,6 +230,10 @@ func (org Organization) ExportArtifact(artifactID string, deadline time.Time) (i
 
 		return gzR, nil
 	}
+	// If the data contains an inline payload, just return it.
+	if resp.Payload != "" {
+		return io.NopCloser(base64.NewDecoder(base64.StdEncoding, strings.NewReader(resp.Payload))), nil
+	}
 	c := http.Client{
 		Timeout: 30 * time.Second,
 	}

--- a/limacharlie/artifact.go
+++ b/limacharlie/artifact.go
@@ -47,7 +47,7 @@ type artifactExportResp struct {
 
 var maxUploadFilePartSize = int64(1024 * 1024)
 
-const concurrentUploads = 1
+const concurrentUploads = 10
 
 func (org Organization) artifact(responseData interface{}, action string, req Dict) error {
 	reqData := req

--- a/limacharlie/artifact_test.go
+++ b/limacharlie/artifact_test.go
@@ -30,7 +30,9 @@ func TestArtifactUpload(t *testing.T) {
 
 	// Download the artifact to make sure it's there.
 	r, err := org.ExportArtifact("", time.Now().Add(1*time.Minute))
-	a.NoError(err)
+	if err != nil {
+		t.Fatal(err)
+	}
 	b, err := io.ReadAll(r)
 	a.NoError(err)
 	if string(b) != string(testData) {

--- a/limacharlie/artifact_test.go
+++ b/limacharlie/artifact_test.go
@@ -1,7 +1,9 @@
 package limacharlie
 
 import (
+	"io"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -25,6 +27,15 @@ func TestArtifactUpload(t *testing.T) {
 
 	// delete ingestion key
 	resp, _ = org.DelIngestionKeys("__test_key")
+
+	// Download the artifact to make sure it's there.
+	r, err := org.ExportArtifact("", time.Now().Add(1*time.Minute))
+	a.NoError(err)
+	b, err := io.ReadAll(r)
+	a.NoError(err)
+	if string(b) != string(testData) {
+		t.Fatalf("artifact data mismatch: %s != %s", string(b), string(testData))
+	}
 }
 
 func TestLoggingAddDelete(t *testing.T) {

--- a/limacharlie/artifact_test.go
+++ b/limacharlie/artifact_test.go
@@ -23,13 +23,14 @@ func TestArtifactUpload(t *testing.T) {
 	// Tweak the artifact part size to make sure we test the multipart upload.
 	maxUploadFilePartSize = 15
 
-	a.NoError(org.CreateArtifactFromBytes(testName, testData, "txt", uuid.New().String(), 1, ingestionKey.(string)))
+	artifactID := uuid.New().String()
+	a.NoError(org.CreateArtifactFromBytes(testName, testData, "txt", artifactID, 1, ingestionKey.(string)))
 
 	// delete ingestion key
 	resp, _ = org.DelIngestionKeys("__test_key")
 
 	// Download the artifact to make sure it's there.
-	r, err := org.ExportArtifact("", time.Now().Add(1*time.Minute))
+	r, err := org.ExportArtifact(artifactID, time.Now().Add(1*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description of the change

Re-enabling parallel upload of artifacts now that the ingestion service supports it.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

