### PR TITLE
Fix storage client passed by value.

### DIFF
--- a/limacharlie/artifact.go
+++ b/limacharlie/artifact.go
@@ -266,7 +266,7 @@ func (org Organization) ExportArtifact(artifactID string, deadline time.Time) (i
 	return httpResp.Body, nil
 }
 
-func (org Organization) ExportArtifactThroughGCS(ctx context.Context, artifactID string, deadline time.Time, bucketName string, writeCreds string, readClient storage.Client) (io.ReadCloser, error) {
+func (org Organization) ExportArtifactThroughGCS(ctx context.Context, artifactID string, deadline time.Time, bucketName string, writeCreds string, readClient *storage.Client) (io.ReadCloser, error) {
 	resp := artifactExportResp{}
 	var request restRequest
 	request = makeDefaultRequest(&resp).withQueryData(Dict{


### PR DESCRIPTION
## Description of the change

The SDK provides the client as a ptr to a client. They might be using locks or other values within that expect to be passed by reference and not value.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

