### PR TITLE
Increase the default timeout.

### DIFF
--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -24,7 +24,7 @@ const (
 	getJWTURL         = "https://jwt.limacharlie.io"
 
 	restRetries          = 3
-	restTimeout          = 5 * time.Second
+	restTimeout          = 30 * time.Second
 	restCreateOrgTimeout = 35 * time.Second
 )
 


### PR DESCRIPTION
## Description of the change

Increase the API call default timeout, it's often problematic when returning long running operations and 30 seconds should be plenty.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

