### PR TITLE
Add TagBlackList field to OutputConfig

### DIFF
--- a/limacharlie/output.go
+++ b/limacharlie/output.go
@@ -103,6 +103,7 @@ type OutputConfig struct {
 	PayloadAsString   bool   `json:"is_payload_as_string,omitempty,string" yaml:"is_payload_as_string,omitempty"`
 	InvestigationID   string `json:"inv_id,omitempty" yaml:"inv_id,omitempty"`
 	Tag               string `json:"tag,omitempty" yaml:"tag,omitempty"`
+	TagBlackList      string `json:"tag_black_list,omitempty" yaml:"tag_black_list,omitempty"`
 	Category          string `json:"cat,omitempty" yaml:"cat,omitempty"`
 	SensorID          string `json:"sid,omitempty" yaml:"sid,omitempty"`
 	Flat              bool   `json:"is_flat,omitempty,string" yaml:"is_flat,omitempty"`


### PR DESCRIPTION
## Summary
- Added `TagBlackList` field to OutputConfig struct in the Go SDK
- Enables programmatic configuration of tag blacklist filtering for outputs

## Changes
- Added `TagBlackList` field to `OutputConfig` struct in `limacharlie/output.go`
- Field positioned after existing `Tag` field for consistency
- Uses standard json/yaml tag naming convention (`tag_black_list`)

## Impact
SDK users can now programmatically configure tag blacklisting when creating or updating outputs through the API.

## Test plan
- [ ] Verify SDK properly serializes/deserializes TagBlackList field
- [ ] Test creating outputs with tag_black_list via SDK
- [ ] Confirm backward compatibility with existing code

🤖 Generated with [Claude Code](https://claude.ai/code)