### PR TITLE
Migrate billing endpoints from billing-service to lc_api-go

### DIFF
--- a/limacharlie/billing.go
+++ b/limacharlie/billing.go
@@ -6,10 +6,6 @@ import (
 	"net/http"
 )
 
-const (
-	billingRootURL = "https://billing.limacharlie.io"
-)
-
 // BillingOrgStatus contains the billing status information for an organization
 type BillingOrgStatus struct {
 	IsPastDue bool `json:"is_past_due,omitempty"`
@@ -40,6 +36,7 @@ type BillingInvoiceURL struct {
 type BillingPlan struct {
 	ID          string                 `json:"id,omitempty"`
 	Name        string                 `json:"name,omitempty"`
+	Region      string                 `json:"region,omitempty"`
 	Description string                 `json:"description,omitempty"`
 	Price       float64                `json:"price,omitempty"`
 	Currency    string                 `json:"currency,omitempty"`
@@ -56,9 +53,9 @@ type BillingUserAuthRequirements struct {
 // GetBillingOrgStatus retrieves the billing status for the organization
 func (org *Organization) GetBillingOrgStatus() (*BillingOrgStatus, error) {
 	var status BillingOrgStatus
-	url := fmt.Sprintf("orgs/%s/status", org.GetOID())
+	url := fmt.Sprintf("orgs/%s/billing/status", org.GetOID())
 
-	request := makeDefaultRequest(&status).withURLRoot(billingRootURL + "/")
+	request := makeDefaultRequest(&status)
 
 	if err := org.client.reliableRequest(context.Background(), http.MethodGet, url, request); err != nil {
 		return nil, err
@@ -70,9 +67,9 @@ func (org *Organization) GetBillingOrgStatus() (*BillingOrgStatus, error) {
 // GetBillingOrgDetails retrieves detailed billing information for the organization
 func (org *Organization) GetBillingOrgDetails() (*BillingOrgDetails, error) {
 	var details BillingOrgDetails
-	url := fmt.Sprintf("orgs/%s/details", org.GetOID())
+	url := fmt.Sprintf("orgs/%s/billing/details", org.GetOID())
 
-	request := makeDefaultRequest(&details).withURLRoot(billingRootURL + "/")
+	request := makeDefaultRequest(&details)
 
 	if err := org.client.reliableRequest(context.Background(), http.MethodGet, url, request); err != nil {
 		return nil, err
@@ -101,12 +98,12 @@ func (org *Organization) GetBillingInvoiceURL(year, month int, format string) (m
 	}
 
 	response := make(map[string]interface{})
-	urlPath := fmt.Sprintf("orgs/%s/invoice_url/%d/%02d", org.GetOID(), year, month)
+	urlPath := fmt.Sprintf("orgs/%s/billing/invoice/%d/%02d", org.GetOID(), year, month)
 	if format != "" {
 		urlPath = fmt.Sprintf("%s?format=%s", urlPath, format)
 	}
 
-	request := makeDefaultRequest(&response).withURLRoot(billingRootURL + "/")
+	request := makeDefaultRequest(&response)
 
 	if err := org.client.reliableRequest(context.Background(), http.MethodGet, urlPath, request); err != nil {
 		return nil, err
@@ -115,15 +112,45 @@ func (org *Organization) GetBillingInvoiceURL(year, month int, format string) (m
 	return response, nil
 }
 
+// SkuDefinition contains metadata and pricing information for a metered SKU
+type SkuDefinition struct {
+	SkuID       string                 `json:"sku_id"`
+	PlanID      string                 `json:"plan_id"`
+	Category    string                 `json:"category"`
+	Label       string                 `json:"label"`
+	Description string                 `json:"description"`
+	UnitType    string                 `json:"unit_type"`
+	UnitLabel   string                 `json:"unit_label"`
+	MetaProduct string                 `json:"meta_product"`
+	Pricing     map[string]interface{} `json:"pricing,omitempty"`
+	Error       string                 `json:"error,omitempty"`
+}
+
+// GetBillingSkuDefinitions retrieves metered SKU definitions with metadata and pricing
+func (org *Organization) GetBillingSkuDefinitions() ([]SkuDefinition, error) {
+	var response struct {
+		Skus []SkuDefinition `json:"skus"`
+	}
+	url := fmt.Sprintf("orgs/%s/billing/sku", org.GetOID())
+
+	request := makeDefaultRequest(&response)
+
+	if err := org.client.reliableRequest(context.Background(), http.MethodGet, url, request); err != nil {
+		return nil, err
+	}
+
+	return response.Skus, nil
+}
+
 // GetBillingAvailablePlans retrieves the list of available billing plans for the user
 func (org *Organization) GetBillingAvailablePlans() ([]BillingPlan, error) {
 	// Server wraps response in {"plans": [...]}
 	var response struct {
 		Plans []BillingPlan `json:"plans"`
 	}
-	url := "user/self/plans"
+	url := "plans"
 
-	request := makeDefaultRequest(&response).withURLRoot(billingRootURL + "/")
+	request := makeDefaultRequest(&response)
 
 	if err := org.client.reliableRequest(context.Background(), http.MethodGet, url, request); err != nil {
 		return nil, err
@@ -137,7 +164,7 @@ func (org *Organization) GetBillingUserAuthRequirements() (*BillingUserAuthRequi
 	var authReq BillingUserAuthRequirements
 	url := "user/self/auth"
 
-	request := makeDefaultRequest(&authReq).withURLRoot(billingRootURL + "/")
+	request := makeDefaultRequest(&authReq)
 
 	if err := org.client.reliableRequest(context.Background(), http.MethodGet, url, request); err != nil {
 		return nil, err

--- a/limacharlie/billing_test.go
+++ b/limacharlie/billing_test.go
@@ -116,9 +116,8 @@ func TestGetBillingAvailablePlans(t *testing.T) {
 	org := getTestOrgFromEnv(a)
 
 	_, err := org.GetBillingAvailablePlans()
-	// When using API key authentication (non-user identity), expect this specific error
+	// When using API key authentication (non-user identity), expect an error
 	a.Error(err, "Should return error for non-user identity")
-	a.Contains(err.Error(), "only user-based identities are allowed to query available plans")
 	t.Logf("Expected error received: %s", err.Error())
 }
 

--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -35,7 +35,6 @@ type Client struct {
 	httpClient *http.Client
 	baseURL    string // overrides rootURL when non-empty
 	jwtURL     string // overrides getJWTURL when non-empty
-	billingURL string // overrides billingRootURL when non-empty
 }
 
 // ClientOptions holds all options for Client
@@ -90,11 +89,6 @@ func (r restRequest) withQueryData(queryData interface{}) restRequest {
 
 func (r restRequest) withURLValues(urlValues url.Values) restRequest {
 	r.urlValues = urlValues
-	return r
-}
-
-func (r restRequest) withURLRoot(root string) restRequest {
-	r.urlRoot = root
 	return r
 }
 
@@ -403,12 +397,7 @@ func (c *Client) request(ctx context.Context, verb string, path string, request 
 	// Build the URL - if urlRoot is a full URL (starts with http), use it as base, otherwise concatenate
 	var fullURL string
 	if strings.HasPrefix(request.urlRoot, "http://") || strings.HasPrefix(request.urlRoot, "https://") {
-		effectiveRoot := request.urlRoot
-		// If a billing URL override is set, replace the billing root URL
-		if c.billingURL != "" && strings.HasPrefix(request.urlRoot, billingRootURL) {
-			effectiveRoot = c.billingURL + strings.TrimPrefix(request.urlRoot, billingRootURL)
-		}
-		fullURL = fmt.Sprintf("%s%s", effectiveRoot, path)
+		fullURL = fmt.Sprintf("%s%s", request.urlRoot, path)
 	} else {
 		base := c.baseURL
 		if base == "" {

--- a/limacharlie/mock.go
+++ b/limacharlie/mock.go
@@ -262,7 +262,6 @@ func (ms *MockServer) NewClient() (*Client, error) {
 		httpClient: ms.Server.Client(),
 		baseURL:    ms.Server.URL,
 		jwtURL:     ms.Server.URL + "/jwt",
-		billingURL: ms.Server.URL,
 	}, nil
 }
 

--- a/limacharlie/mock.go
+++ b/limacharlie/mock.go
@@ -343,12 +343,12 @@ func (ms *MockServer) registerRoutes(mux *http.ServeMux) {
 	// Hostnames
 	mux.HandleFunc(fmt.Sprintf("/v1/hostnames/%s", ms.OID), ms.handleHostnames)
 
-	// Billing (no /v1/ prefix - billing service uses its own root URL)
-	mux.HandleFunc(fmt.Sprintf("/orgs/%s/status", ms.OID), ms.handleBillingStatus)
-	mux.HandleFunc(fmt.Sprintf("/orgs/%s/details", ms.OID), ms.handleBillingDetails)
-	mux.HandleFunc(fmt.Sprintf("/orgs/%s/invoice_url/", ms.OID), ms.handleBillingInvoice)
-	mux.HandleFunc("/user/self/plans", ms.handleBillingPlans)
-	mux.HandleFunc("/user/self/auth", ms.handleBillingAuth)
+	// Billing
+	mux.HandleFunc(fmt.Sprintf("/v1/orgs/%s/billing/status", ms.OID), ms.handleBillingStatus)
+	mux.HandleFunc(fmt.Sprintf("/v1/orgs/%s/billing/details", ms.OID), ms.handleBillingDetails)
+	mux.HandleFunc(fmt.Sprintf("/v1/orgs/%s/billing/invoice/", ms.OID), ms.handleBillingInvoice)
+	mux.HandleFunc("/v1/plans", ms.handleBillingPlans)
+	mux.HandleFunc("/v1/user/self/auth", ms.handleBillingAuth)
 
 	// Groups
 	mux.HandleFunc("/v1/groups/concurrent", ms.handleGroupsConcurrent)


### PR DESCRIPTION
## Summary

Billing functionality has been migrated server-side from the legacy `billing.limacharlie.io` service to `lc_api-go` (served at `api.limacharlie.io/v1/`). This PR points the SDK at the new endpoints so consumers don't drift out of sync as the legacy service is retired.

### Path changes
| Method | Old path | New path |
|---|---|---|
| `GetBillingOrgStatus` | `orgs/{oid}/status` (billing root) | `orgs/{oid}/billing/status` |
| `GetBillingOrgDetails` | `orgs/{oid}/details` (billing root) | `orgs/{oid}/billing/details` |
| `GetBillingInvoiceURL` | `orgs/{oid}/invoice_url/{y}/{m}` (billing root) | `orgs/{oid}/billing/invoice/{y}/{m}` |
| `GetBillingAvailablePlans` | `user/self/plans` (billing root) | `plans` |
| `GetBillingUserAuthRequirements` | `user/self/auth` (billing root) | `user/self/auth` (default root) |
| `GetBillingSkuDefinitions` *(new)* | — | `orgs/{oid}/billing/sku` |

### Other cleanup
- Drops `billingRootURL` constant, `Client.billingURL` override, and the `withURLRoot` helper — all dead after the migration.
- Adds `Region` to `BillingPlan` to capture the new field in the `plans` response.

## Semantic parity

Compared each migrated endpoint against its legacy counterpart in `billing-services/billing-service`. Caller-visible differences:

- **`/billing/invoice/{y}/{m}`** — lc_api-go returns only the first paid/open invoice for a month. The legacy `urls[]` / `invoices[]` multi-invoice keys are gone. Single-URL consumers (the common case) are unaffected since `GetBillingInvoiceURL` returns `map[string]interface{}`.
- **`/plans`** — response is narrower (`{id, name, region}`) than the legacy shape (`{ID, MetaProduct, Datacenter:{Name, Region}}`). Struct fields the server never populated either way (`Description`, `Price`, `Currency`, `Features`, `Extra`) stay zero-valued just as before. `Name` is newly populated; `Region` captured via the new field.
- **`/user/self/auth`** — error message for non-user identities unchanged (`"only user-based identities are allowed to query authentication requirements"`); lc_api-go additionally returns a top-level `is_unified_billing` which the SDK struct doesn't surface.
- `/billing/status`, `/billing/details` — identical response shape.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [ ] `TestBillingOrgStatus`, `TestBillingOrgDetails`, `TestGetBillingInvoiceURL`, `TestGetBillingInvoiceURLWithFormat`, `TestGetBillingInvoiceURLValidation`, `TestGetBillingAvailablePlans`, `TestGetBillingUserAuthRequirements` run against a real org
- [ ] Verify no downstream consumers rely on the removed `urls[]` / `invoices[]` response keys from `GetBillingInvoiceURL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)