### PR TITLE
Register ai_skill and ai_memory hives for sync

### DIFF
--- a/limacharlie/sync.go
+++ b/limacharlie/sync.go
@@ -64,6 +64,8 @@ var KnownHives = []string{
 	"model",
 	"playbook",
 	"ai_agent",
+	"ai_skill",
+	"ai_memory",
 	"external_adapter",
 }
 
@@ -93,6 +95,8 @@ func SyncAll() SyncOptions {
 			"query":            true,
 			"playbook":         true,
 			"ai_agent":         true,
+			"ai_skill":         true,
+			"ai_memory":        true,
 			"external_adapter": true,
 		},
 	}


### PR DESCRIPTION
## Summary
- Add the two new hive names recently introduced in `legion_config_hive` to `KnownHives` and the `SyncAll()` map so they are picked up by `SyncFetch` / `SyncPush`:
  - `ai_skill` (legion_config_hive #282)
  - `ai_memory` (legion_config_hive #288)
- The third recent change in `legion_config_hive` — `ai_agent` Bedrock/Vertex provider blocks (#287) — needs no SDK update here, since hive `Data` is an opaque `Dict` to this client.

## Test plan
- [ ] `go build ./...` (passes locally)
- [ ] Spot-check: `SyncAll()` returns `SyncHives["ai_skill"] == true` and `SyncHives["ai_memory"] == true`
- [ ] Live `SyncFetch` against an org with `ai_skill` / `ai_memory` records pulls them down

🤖 Generated with [Claude Code](https://claude.com/claude-code)