### PR TITLE
Remove model hive from sync priority list

### DIFF
--- a/limacharlie/sync.go
+++ b/limacharlie/sync.go
@@ -61,7 +61,6 @@ var KnownHives = []string{
 	"secret",
 	"lookup",
 	"query",
-	"model",
 	"playbook",
 	"ai_agent",
 	"ai_skill",
@@ -1000,7 +999,7 @@ func (org *Organization) SyncPush(conf OrgConfig, options SyncOptions) ([]OrgSyn
 	}
 	// We will sync manually a few hives specifically here to avoid cases
 	// where a new resource uses a record and it's not there yet.
-	for _, hive := range []string{"secret", "yara", "lookup", "model"} {
+	for _, hive := range []string{"secret", "yara", "lookup"} {
 		if isEnabled, ok := options.SyncHives[hive]; ok && isEnabled && len(conf.Hives[hive]) > 0 {
 			justOne := orgSyncHives{
 				hive: conf.Hives[hive],


### PR DESCRIPTION
## Summary

The `legion_models` system is being decommissioned. The `model` hive definition is being removed in **legion_config_hive#289**; once that lands, any sync attempt against the `model` hive returns `UNKNOWN_HIVE`. This PR drops the SDK's references to the `model` hive type.

## Changes

- `limacharlie/sync.go:64` — removed `"model"` from `KnownHives` (the published list of hive types).
- `limacharlie/sync.go:1003` (now line 1002) — removed `"model"` from the priority-sync slice in `SyncPush`. Was: `[]string{"secret", "yara", "lookup", "model"}`. Now: `[]string{"secret", "yara", "lookup"}`.

`SyncAll()` no longer enabled the `model` hive (removed in #215), so the default sync path was already model-free.

## User-visible behavior after this lands

Verified by reading `limacharlie/sync_hive.go:59-71` and `limacharlie/sync.go:1003,1071`.

- **Default path (`SyncAll()`):** unchanged. `SyncAll()` does not set `SyncHives["model"] = true`, so neither the priority pass nor the generic pass touches the `model` hive. No errors.
- **User config containing a `model:` block under `hives:` but who does NOT explicitly set `SyncHives["model"] = true`:** silently skipped. The generic `syncHive` pass at `sync_hive.go:69` short-circuits when `opts.SyncHives[hiveName]` is false, so the block is ignored entirely. No request is sent. No error.
- **User who explicitly sets `SyncHives["model"] = true` AND has a `model:` block:** will fail with `UNKNOWN_HIVE` once legion_config_hive#289 lands. The generic pass at `sync.go:1071` still iterates over `conf.Hives` and will call `fetchHiveConfigData` for any hive name that's both in the user's config and in `opts.SyncHives`. This PR removes `model` from the priority list, so the call no longer happens twice — but the generic pass still attempts it. Eliminating that path entirely would require a name-allowlist filter inside `syncHive`; out of scope here. The vast majority of users go through `SyncAll()` and are unaffected.

## Test plan

- [x] `go build ./...` — clean (limacharlie + firehose modules).
- [x] `go vet ./...` — clean.
- [x] `go test -run NONE -count=1 ./...` — tests compile.
- [x] `grep -rn '"model"\|"model_relationship"\|legion_models\|model_definition' --include='*.go' .` — zero matches after the edit.
- [ ] Integration tests (`limacharlie/run_test.sh`) require Docker + `LC_TEST_OID`/`LC_TEST_KEY`; not run locally. Change is a string-list edit with no behavior change for `SyncAll()` users; risk is low.