### PR TITLE
Fix HiveClient.Update wholesale-replacing UsrMtd with zero values for unauthored fields

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,21 @@
+# Release Notes
+
+## Unreleased
+
+- Fix `HiveClient.Update` wholesale-replacing `usr_mtd` with Go zero values for fields the caller did not author.
+
+  Before this change, the hive sync push flow rebuilt `usr_mtd` from the caller's args alone and sent a fully-populated block on every write. Combined with the server's wholesale-replace semantic on `set_record` and `set_record_mtd`, any field the caller did not explicitly author landed on the wire as a zero value (`enabled: false`, `expiry: 0`, `tags: nil`, `comment: ""`) and overwrote whatever was on the record.
+
+  The most visible consequence was silent disable: YAML that omitted `usr_mtd:` (or only partially populated it) for an existing rule would, on the next sync push, flip the rule to disabled and strip its tags/comment/expiry, without any error or warning.
+
+  `HiveClient.Update` now fetches the existing record (which it already did for etag handling) and uses its `usr_mtd` as the merge base. Only fields the caller explicitly set via non-nil `Enabled`/`Expiry`/`Comment` pointers or non-nil `Tags` slice overlay the existing values; everything else is preserved. The server's existing etag CAS continues to gate the write, so a concurrent writer between the SDK's fetch and the SDK's POST surfaces as `ETAG_MISMATCH` instead of a silent stomp.
+
+  The sync push flow (`SyncHiveData` + `syncHive`) now tracks which `usr_mtd` keys were authored in the source YAML via a custom `UnmarshalYAML`, and forwards only authored fields to `HiveClient.Update`. Sparse YAML stops mutating fields the user did not author. `Equals` is presence-aware so sparse YAML matching current state no longer triggers spurious no-op `UPDATE` calls.
+
+  `HiveClient.Add` defaults `Enabled: true` for YAML-loaded new records when the YAML did not specify enabled, since declaring a rule via IaC almost always implies the author wants it active. Direct callers passing explicit pointer args are unaffected.
+
+  Tag semantic is now explicit at the SDK boundary: `Tags: nil` preserves existing tags, `Tags: []string{}` (non-nil empty slice) clears them.
+
+  Behavior change to be aware of for direct `HiveClient.Update` callers: a caller passing a non-nil pointer with an explicit zero value (e.g. `Enabled: &false`) still gets that zero applied. A caller passing nil pointers - which previously silently wiped fields to Go zero values - now preserves the existing field. This is strictly the friendlier semantic and matches what such callers almost certainly intended. No public type signatures changed.
+
+  See [#243](https://github.com/refractionPOINT/go-limacharlie/pull/243) for details, including the related wire-format-ambiguity issues elsewhere in the sync flow that are scoped for follow-up.

--- a/limacharlie/hive.go
+++ b/limacharlie/hive.go
@@ -287,6 +287,18 @@ func (h *HiveClient) Add(args HiveArgs) (*HiveResp, error) {
 	return &hiveResp, nil
 }
 
+// Update modifies an existing hive record. The server's set_record and
+// set_record_mtd RPCs wholesale-replace the record's usr_mtd block on every
+// write, so to avoid silently zeroing out fields the caller did not author
+// we merge here: fetch the current usr_mtd, overlay only the fields the
+// caller explicitly set (non-nil pointer args, or non-nil Tags slice), and
+// send the merged result back. The server's existing etag check still gates
+// the write, so a concurrent writer between our fetch and our POST surfaces
+// as ETAG_MISMATCH rather than a silent stomp.
+//
+// Tag handling: args.Tags == nil means "preserve existing tags";
+// args.Tags == []string{} (non-nil empty slice) means "clear all tags". The
+// distinction is preserved at the SDK boundary and on the wire.
 func (h *HiveClient) Update(args HiveArgs) (*HiveResp, error) {
 	if args.Key == "" {
 		return nil, errors.New("key required")
@@ -309,8 +321,12 @@ func (h *HiveClient) Update(args HiveArgs) (*HiveResp, error) {
 		}
 	}
 
-	// set usr mtd data
-	var usrMtd UsrMtd
+	// Merge: start from the fetched usr_mtd and overlay only authored fields.
+	// A nil pointer means the caller did not author the field, so we keep the
+	// existing value. This preserves enabled/expiry/tags/comment that the
+	// caller did not touch, instead of letting them get wiped to Go zero
+	// values when the server replaces usr_mtd wholesale.
+	usrMtd := existing.UsrMtd
 	if args.Expiry != nil {
 		usrMtd.Expiry = *args.Expiry
 	}

--- a/limacharlie/mock.go
+++ b/limacharlie/mock.go
@@ -1143,11 +1143,20 @@ func (ms *MockServer) handleHive(w http.ResponseWriter, r *http.Request) {
 		// target=mtd corresponds to the set_record_mtd RPC, which only mutates
 		// the metadata of an existing record and returns RECORD_NOT_FOUND
 		// otherwise. target=data is set_record, an upsert.
+		//
+		// Both branches honor etag CAS the same way prod does: if the request
+		// carries an etag (mtd: via the dedicated "etag" form field; data:
+		// via sys_mtd.etag) and it doesn't match the stored record, return
+		// ETAG_MISMATCH so tests can exercise concurrent-write rejection.
 		if target == "mtd" {
 			records := ms.HiveStore[storeKey]
 			existing, ok := records[key]
 			if records == nil || !ok {
 				ms.writeError(w, 404, "RECORD_NOT_FOUND")
+				return
+			}
+			if reqEtag := form.Get("etag"); reqEtag != "" && reqEtag != existing.SysMtd.Etag {
+				ms.writeError(w, 409, "ETAG_MISMATCH")
 				return
 			}
 			existing.UsrMtd = usrMtd
@@ -1163,6 +1172,13 @@ func (ms *MockServer) handleHive(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// target=data (set_record): upsert path. If the record already exists
+		// and the request carries an etag, enforce it before overwriting.
+		if existing, ok := ms.HiveStore[storeKey][key]; ok && sysMtd.Etag != "" && sysMtd.Etag != existing.SysMtd.Etag {
+			ms.writeError(w, 409, "ETAG_MISMATCH")
+			return
+		}
+
 		if ms.HiveStore[storeKey] == nil {
 			ms.HiveStore[storeKey] = map[string]HiveData{}
 		}
@@ -1170,14 +1186,23 @@ func (ms *MockServer) handleHive(w http.ResponseWriter, r *http.Request) {
 		guid := uuid.New().String()
 		etag := uuid.New().String()
 
+		// Preserve created-by/created-at on overwrite of an existing record.
+		createdBy := "mock"
+		createdAt := time.Now().Unix()
+		if existing, ok := ms.HiveStore[storeKey][key]; ok {
+			createdBy = existing.SysMtd.CreatedBy
+			createdAt = existing.SysMtd.CreatedAt
+			guid = existing.SysMtd.GUID
+		}
+
 		ms.HiveStore[storeKey][key] = HiveData{
 			Data:   data,
 			UsrMtd: usrMtd,
 			SysMtd: SysMtd{
 				Etag:       etag,
 				GUID:       guid,
-				CreatedBy:  "mock",
-				CreatedAt:  time.Now().Unix(),
+				CreatedBy:  createdBy,
+				CreatedAt:  createdAt,
 				LastAuthor: "mock",
 				LastMod:    time.Now().Unix(),
 			},

--- a/limacharlie/sync_hive.go
+++ b/limacharlie/sync_hive.go
@@ -8,9 +8,107 @@ import (
 )
 
 type SyncHiveConfigData map[string]SyncHiveData
+
+// SyncHiveData carries one hive record's data and metadata through the sync
+// flow. The presence field is populated by UnmarshalYAML and records which
+// usr_mtd keys were authored in the source YAML, so that the sync write path
+// can send only those fields on the wire (and so Equals only diffs them).
+// Unauthored fields are preserved by HiveClient.Update via a client-side
+// merge against the existing record's metadata, gated by the existing etag
+// CAS to keep concurrent writers safe.
+//
+// presenceUsed distinguishes "presence info is reliable" (YAML decode, or
+// AsSyncData from a fetched record) from "no presence info available, fall
+// back to legacy semantics" (a struct literal built by an external caller).
+// Direct callers that want presence-aware semantics should populate via
+// AsSyncData or the SyncHiveData methods.
 type SyncHiveData struct {
-	Data   map[string]interface{} `json:"data" yaml:"data,omitempty"`
-	UsrMtd UsrMtd                 `json:"usr_mtd" yaml:"usr_mtd"`
+	Data         map[string]interface{} `json:"data" yaml:"data,omitempty"`
+	UsrMtd       UsrMtd                 `json:"usr_mtd" yaml:"usr_mtd"`
+	presence     usrMtdPresence         `json:"-" yaml:"-"`
+	presenceUsed bool                   `json:"-" yaml:"-"`
+}
+
+// usrMtdPresence tracks which usr_mtd keys the YAML actually authored. Nil
+// pointer means the YAML omitted the field; non-nil means the YAML set it
+// (including to its zero value).
+type usrMtdPresence struct {
+	Enabled *bool
+	Expiry  *int64
+	Tags    *[]string
+	Comment *string
+}
+
+// UnmarshalYAML decodes a SyncHiveData while recording which usr_mtd keys
+// were present in the source YAML. The decode is two-stage: first into a
+// map keyed by yaml.Node so key presence is observable, then into typed
+// values for each present key. presenceUsed is set unconditionally on a
+// successful decode so that "YAML with no usr_mtd block" is distinguishable
+// from "struct literal with no presence info."
+func (s *SyncHiveData) UnmarshalYAML(node *yaml.Node) error {
+	var raw struct {
+		Data   map[string]interface{} `yaml:"data"`
+		UsrMtd map[string]yaml.Node   `yaml:"usr_mtd"`
+	}
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+	s.Data = raw.Data
+	s.presenceUsed = true
+	if n, ok := raw.UsrMtd["enabled"]; ok {
+		var v bool
+		if err := n.Decode(&v); err != nil {
+			return err
+		}
+		s.UsrMtd.Enabled = v
+		s.presence.Enabled = &v
+	}
+	if n, ok := raw.UsrMtd["expiry"]; ok {
+		var v int64
+		if err := n.Decode(&v); err != nil {
+			return err
+		}
+		s.UsrMtd.Expiry = v
+		s.presence.Expiry = &v
+	}
+	if n, ok := raw.UsrMtd["tags"]; ok {
+		var v []string
+		if err := n.Decode(&v); err != nil {
+			return err
+		}
+		s.UsrMtd.Tags = v
+		s.presence.Tags = &v
+	}
+	if n, ok := raw.UsrMtd["comment"]; ok {
+		var v string
+		if err := n.Decode(&v); err != nil {
+			return err
+		}
+		s.UsrMtd.Comment = v
+		s.presence.Comment = &v
+	}
+	return nil
+}
+
+// resolvedPresence returns the effective presence for write/diff. When the
+// caller did not populate presence (struct literal path), every field is
+// treated as authored so existing callers keep their old "send all fields"
+// semantics. When presence was populated (YAML or AsSyncData), it is
+// returned as-is so unauthored fields stay nil and get merged server-side.
+func (s *SyncHiveData) resolvedPresence() usrMtdPresence {
+	if s.presenceUsed {
+		return s.presence
+	}
+	enabled := s.UsrMtd.Enabled
+	expiry := s.UsrMtd.Expiry
+	tags := s.UsrMtd.Tags
+	comment := s.UsrMtd.Comment
+	return usrMtdPresence{
+		Enabled: &enabled,
+		Expiry:  &expiry,
+		Tags:    &tags,
+		Comment: &comment,
+	}
 }
 
 func (org *Organization) syncFetchHive(syncHiveOpts map[string]bool) (orgSyncHives, error) {
@@ -200,6 +298,12 @@ func (org *Organization) fetchHiveConfigData(args HiveArgs) (SyncHiveConfigData,
 	return currentHiveDataConfig, nil
 }
 
+// updateHiveConfigData forwards only the usr_mtd fields the YAML authored to
+// HiveClient.Update. Fields the YAML omitted are passed as nil pointers so
+// that the update path merges them against the existing record's metadata
+// instead of overwriting them with Go zero values. Callers building
+// SyncHiveData via struct literal (no presence info) keep the legacy "send
+// every field" behavior through resolvedPresence.
 func (org *Organization) updateHiveConfigData(ha HiveArgs, hd SyncHiveData) error {
 	hiveClient := NewHiveClient(org)
 
@@ -208,19 +312,16 @@ func (org *Organization) updateHiveConfigData(ha HiveArgs, hd SyncHiveData) erro
 		return err
 	}
 
-	enabled := hd.UsrMtd.Enabled
-	expiry := hd.UsrMtd.Expiry
-	tags := hd.UsrMtd.Tags
-	comment := hd.UsrMtd.Comment
+	p := hd.resolvedPresence()
 	args := HiveArgs{
 		Key:          ha.Key,
 		PartitionKey: ha.PartitionKey,
 		HiveName:     ha.HiveName,
 		Data:         hd.Data,
-		Enabled:      &enabled,
-		Expiry:       &expiry,
-		Tags:         tags,
-		Comment:      &comment,
+		Enabled:      p.Enabled,
+		Expiry:       p.Expiry,
+		Tags:         derefTags(p.Tags),
+		Comment:      p.Comment,
 	}
 
 	_, err = hiveClient.Update(args) // run actual update call
@@ -230,6 +331,13 @@ func (org *Organization) updateHiveConfigData(ha HiveArgs, hd SyncHiveData) erro
 	return nil
 }
 
+// addHiveConfigData forwards only the usr_mtd fields the YAML authored to
+// HiveClient.Add. New records default to enabled=true when YAML-loaded data
+// did not specify enabled, since declaring a rule via IaC almost always
+// implies the author wants it active; a record created in the disabled
+// state with no explicit intent looks like a successful deploy but never
+// fires. Struct-literal callers keep their explicit Enabled value through
+// resolvedPresence, so this default only fires for YAML pushes.
 func (org *Organization) addHiveConfigData(ha HiveArgs, hd SyncHiveData) error {
 	hiveClient := NewHiveClient(org)
 
@@ -238,19 +346,22 @@ func (org *Organization) addHiveConfigData(ha HiveArgs, hd SyncHiveData) error {
 		return err
 	}
 
-	enabled := hd.UsrMtd.Enabled
-	expiry := hd.UsrMtd.Expiry
-	tags := hd.UsrMtd.Tags
-	comment := hd.UsrMtd.Comment
+	p := hd.resolvedPresence()
+	enabledPtr := p.Enabled
+	if enabledPtr == nil {
+		defaultEnabled := true
+		enabledPtr = &defaultEnabled
+	}
+
 	args := HiveArgs{
 		Key:          ha.Key,
 		PartitionKey: ha.PartitionKey,
 		HiveName:     ha.HiveName,
 		Data:         hd.Data,
-		Enabled:      &enabled,
-		Expiry:       &expiry,
-		Tags:         tags,
-		Comment:      &comment,
+		Enabled:      enabledPtr,
+		Expiry:       p.Expiry,
+		Tags:         derefTags(p.Tags),
+		Comment:      p.Comment,
 	}
 
 	_, err = hiveClient.Add(args)
@@ -258,6 +369,17 @@ func (org *Organization) addHiveConfigData(ha HiveArgs, hd SyncHiveData) error {
 		return err
 	}
 	return nil
+}
+
+// derefTags returns the slice pointed to by p, or nil if p is nil. The
+// distinction matters: a nil pointer means "YAML did not author tags"
+// (preserve existing); a non-nil pointer to an empty slice means "YAML
+// authored an empty tags list" (clear existing).
+func derefTags(p *[]string) []string {
+	if p == nil {
+		return nil
+	}
+	return *p
 }
 
 func (org *Organization) removeHiveConfigData(args HiveArgs) error {
@@ -281,6 +403,18 @@ func encodeDecodeHiveData(hd *map[string]interface{}) error {
 	return yaml.Unmarshal(out, &hd)
 }
 
+// Equals reports whether the YAML-authored record (hsd) matches the current
+// server-side record (cData) for the purposes of deciding whether a sync
+// push needs to issue an UPDATE. Data is always compared. For usr_mtd, only
+// the fields the caller authored are diffed: unauthored fields are equal by
+// definition since the sync write path won't change them anyway (they
+// merge through to the existing value). This prevents spurious UPDATE
+// operations whose only effect would be to re-send the existing mtd, and
+// it keeps the diff aligned with what actually gets written on the wire.
+//
+// For struct-literal callers (no presence info), resolvedPresence treats
+// every field as authored, matching the legacy "compare everything"
+// behavior so existing callers see no observable diff change.
 func (hsd *SyncHiveData) Equals(cData SyncHiveData) (bool, error) {
 	err := encodeDecodeHiveData(&hsd.Data)
 	if err != nil {
@@ -306,27 +440,49 @@ func (hsd *SyncHiveData) Equals(cData SyncHiveData) (bool, error) {
 		return false, nil
 	}
 
-	if len(hsd.UsrMtd.Tags) == 0 {
-		hsd.UsrMtd.Tags = nil
+	p := hsd.resolvedPresence()
+	if p.Enabled != nil && *p.Enabled != cData.UsrMtd.Enabled {
+		return false, nil
 	}
-	newUsrMTd, err := json.Marshal(hsd.UsrMtd)
-	if err != nil {
-		return false, err
+	if p.Expiry != nil && *p.Expiry != cData.UsrMtd.Expiry {
+		return false, nil
 	}
-
-	if len(cData.UsrMtd.Tags) == 0 {
-		cData.UsrMtd.Tags = nil
+	if p.Tags != nil {
+		newTags := *p.Tags
+		curTags := cData.UsrMtd.Tags
+		// Normalise empty-vs-nil before comparing, mirroring the legacy
+		// Equals behavior so `tags: []` and missing-tags-in-current compare
+		// as equal when neither has any entries.
+		if len(newTags) == 0 {
+			newTags = nil
+		}
+		if len(curTags) == 0 {
+			curTags = nil
+		}
+		if !tagsEqual(newTags, curTags) {
+			return false, nil
+		}
 	}
-	curUsrMtd, err := json.Marshal(cData.UsrMtd)
-	if err != nil {
-		return false, err
-	}
-
-	if string(curUsrMtd) != string(newUsrMTd) {
+	if p.Comment != nil && *p.Comment != cData.UsrMtd.Comment {
 		return false, nil
 	}
 
 	return true, nil
+}
+
+// tagsEqual reports whether two tag slices contain the same elements in the
+// same order. Order matters because the server preserves tag order on
+// writes; treating reordered tags as equal would mask real diffs.
+func tagsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (hcd HiveConfigData) AsSyncConfigData() SyncHiveConfigData {
@@ -337,9 +493,24 @@ func (hcd HiveConfigData) AsSyncConfigData() SyncHiveConfigData {
 	return out
 }
 
+// AsSyncData converts a fetched HiveData to SyncHiveData with all usr_mtd
+// fields marked as present. Server-fetched records have values for every
+// metadata field, so a round-trip through SyncPush should treat each field
+// as authored and write it back faithfully.
 func (hd HiveData) AsSyncData() SyncHiveData {
+	enabled := hd.UsrMtd.Enabled
+	expiry := hd.UsrMtd.Expiry
+	tags := hd.UsrMtd.Tags
+	comment := hd.UsrMtd.Comment
 	return SyncHiveData{
 		Data:   hd.Data,
 		UsrMtd: hd.UsrMtd,
+		presence: usrMtdPresence{
+			Enabled: &enabled,
+			Expiry:  &expiry,
+			Tags:    &tags,
+			Comment: &comment,
+		},
+		presenceUsed: true,
 	}
 }

--- a/limacharlie/sync_hive_merge_e2e_test.go
+++ b/limacharlie/sync_hive_merge_e2e_test.go
@@ -1,0 +1,324 @@
+package limacharlie
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// End-to-end coverage for the usr_mtd merge fix. These tests drive a real
+// LimaCharlie API via the standard integration-test pattern (`_OID` and
+// `_KEY` environment variables consumed by getTestOrgFromEnv); they are
+// run automatically by the cloudbuild.yaml step alongside the rest of the
+// integration suite.
+//
+// Hive choice: every test uses the `lookup` hive. Lookup is pure
+// user-data storage with no live side effects (no sensor connection, no
+// detection firing, no extension subscription), and its usr_mtd handling
+// is identical to dr-general - so the merge contract is exercised
+// end-to-end while keeping blast radius near zero.
+//
+// Concurrency / collision safety: each record key is `e2e-mtd-merge-` +
+// a fresh UUID. Two concurrent CI builds against the same test org cannot
+// collide, and stale records from a crashed prior run cannot interfere
+// with a new run.
+//
+// Cleanup: every test registers a t.Cleanup that issues a Remove for the
+// record(s) it created. The cleanup ignores errors (a record that was
+// never created or was already deleted is not a test failure) so test
+// status reflects the assertion, not the teardown.
+//
+// Tests are marked t.Parallel() because they only touch records under
+// their own UUID keys.
+
+const e2eMtdMergeHive = "lookup"
+
+// e2eMtdMergeKey returns a unique record key for a single e2e test run.
+// The collision space is the full UUID space, so concurrent CI runs and
+// stale state cannot accidentally share a key.
+func e2eMtdMergeKey() string {
+	return "e2e-mtd-merge-" + uuid.New().String()
+}
+
+// e2eMtdMergeData builds a lookup-hive-valid data block. The lookup hive
+// rejects records whose lookup_data field is empty, so every test that
+// creates a record needs at least one indicator entry under lookup_data.
+// The indicator key is unique per call so concurrent records don't share
+// content (useful only as defense in depth - the record key itself is
+// already unique).
+func e2eMtdMergeData(indicator string) Dict {
+	return Dict{
+		"lookup_data": Dict{
+			indicator: Dict{},
+		},
+	}
+}
+
+// e2eMtdMergeSetup builds an Organization from env, creates a HiveClient,
+// and registers cleanup that removes any test records the caller added
+// to the returned key set. The caller appends to keys via addKey.
+func e2eMtdMergeSetup(t *testing.T) (org *Organization, hc *HiveClient, addKey func(string)) {
+	t.Helper()
+	a := assert.New(t)
+	org = getTestOrgFromEnv(a)
+	hc = NewHiveClient(org)
+	var created []string
+	addKey = func(k string) {
+		created = append(created, k)
+	}
+	t.Cleanup(func() {
+		for _, k := range created {
+			_, _ = hc.Remove(HiveArgs{
+				HiveName:     e2eMtdMergeHive,
+				PartitionKey: org.GetOID(),
+				Key:          k,
+			})
+		}
+	})
+	return org, hc, addKey
+}
+
+// e2eMtdMergeSeed adds a record to the lookup hive with a full usr_mtd
+// block. Returns once the record is present and visible (the SDK's
+// reliableRequest blocks until the server responds 200).
+func e2eMtdMergeSeed(t *testing.T, hc *HiveClient, oid, key string, data Dict, mtd UsrMtd) {
+	t.Helper()
+	enabled := mtd.Enabled
+	expiry := mtd.Expiry
+	comment := mtd.Comment
+	_, err := hc.Add(HiveArgs{
+		HiveName:     e2eMtdMergeHive,
+		PartitionKey: oid,
+		Key:          key,
+		Data:         data,
+		Enabled:      &enabled,
+		Expiry:       &expiry,
+		Tags:         mtd.Tags,
+		Comment:      &comment,
+	})
+	require.NoError(t, err, "seed Add for key %q must succeed", key)
+}
+
+// e2eMtdMergePush invokes SyncPush against the lookup hive with
+// IsForce=false. IsForce is intentionally off: a force push against a
+// real org's lookup hive would delete every record not present in the
+// test YAML, which would be a destructive side effect on whatever else
+// happens to live in the lookup hive of the test org.
+func e2eMtdMergePush(t *testing.T, org *Organization, yamlSrc string) {
+	t.Helper()
+	var cfg OrgConfig
+	require.NoError(t, yaml.Unmarshal([]byte(yamlSrc), &cfg), "test YAML must parse")
+	_, err := org.SyncPush(cfg, SyncOptions{
+		SyncHives: map[string]bool{e2eMtdMergeHive: true},
+	})
+	require.NoError(t, err, "SyncPush against lookup hive must succeed")
+}
+
+// TestE2ESyncHive_NoUsrMtdBlock_PreservesAll is the headline regression
+// test. A YAML push that carries only `data:` for an existing record
+// must not change enabled/expiry/tags/comment.
+func TestE2ESyncHive_NoUsrMtdBlock_PreservesAll(t *testing.T) {
+	t.Parallel()
+	org, hc, addKey := e2eMtdMergeSetup(t)
+	key := e2eMtdMergeKey()
+	addKey(key)
+
+	originalTags := []string{"e2e-prod", "e2e-team-a"}
+	e2eMtdMergeSeed(t, hc, org.GetOID(), key,
+		e2eMtdMergeData("indicator-original"),
+		UsrMtd{Enabled: true, Expiry: 0, Tags: originalTags, Comment: "e2e-owned"},
+	)
+
+	src := fmt.Sprintf(`
+hives:
+  lookup:
+    %s:
+      data:
+        lookup_data:
+          indicator-updated: {}
+`, key)
+	e2eMtdMergePush(t, org, src)
+
+	hd, err := hc.Get(HiveArgs{HiveName: e2eMtdMergeHive, PartitionKey: org.GetOID(), Key: key})
+	require.NoError(t, err)
+	assert.Contains(t, hd.Data["lookup_data"], "indicator-updated", "data should reflect the YAML value")
+	assert.True(t, hd.UsrMtd.Enabled, "enabled must NOT be silently flipped when YAML omits usr_mtd")
+	assert.Equal(t, int64(0), hd.UsrMtd.Expiry, "expiry must be preserved")
+	assert.ElementsMatch(t, originalTags, hd.UsrMtd.Tags, "tags must be preserved")
+	assert.Equal(t, "e2e-owned", hd.UsrMtd.Comment, "comment must be preserved")
+}
+
+// TestE2ESyncHive_PartialUsrMtd_PreservesUnauthored covers the subtle
+// case: YAML carries usr_mtd with only a tags entry. The new tags must
+// win on the wire, but enabled/expiry/comment must remain untouched.
+func TestE2ESyncHive_PartialUsrMtd_PreservesUnauthored(t *testing.T) {
+	t.Parallel()
+	org, hc, addKey := e2eMtdMergeSetup(t)
+	key := e2eMtdMergeKey()
+	addKey(key)
+
+	e2eMtdMergeSeed(t, hc, org.GetOID(), key,
+		e2eMtdMergeData("indicator-stable"),
+		UsrMtd{Enabled: true, Expiry: 0, Tags: []string{"old"}, Comment: "preserve-me"},
+	)
+
+	src := fmt.Sprintf(`
+hives:
+  lookup:
+    %s:
+      data:
+        lookup_data:
+          indicator-stable: {}
+      usr_mtd:
+        tags: ["new"]
+`, key)
+	e2eMtdMergePush(t, org, src)
+
+	hd, err := hc.Get(HiveArgs{HiveName: e2eMtdMergeHive, PartitionKey: org.GetOID(), Key: key})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"new"}, hd.UsrMtd.Tags, "tags must be the authored value")
+	assert.True(t, hd.UsrMtd.Enabled, "enabled must be preserved when YAML did not author it")
+	assert.Equal(t, "preserve-me", hd.UsrMtd.Comment, "comment must be preserved")
+}
+
+// TestE2ESyncHive_ExplicitEnabledFalse_Disables is the intent-honored
+// case: when the YAML explicitly carries `enabled: false`, the rule must
+// end up disabled. Distinguishes the merge from a naive "always
+// preserve" that would block legitimate disables.
+func TestE2ESyncHive_ExplicitEnabledFalse_Disables(t *testing.T) {
+	t.Parallel()
+	org, hc, addKey := e2eMtdMergeSetup(t)
+	key := e2eMtdMergeKey()
+	addKey(key)
+
+	e2eMtdMergeSeed(t, hc, org.GetOID(), key,
+		e2eMtdMergeData("indicator-x"),
+		UsrMtd{Enabled: true, Tags: []string{"keep"}},
+	)
+
+	src := fmt.Sprintf(`
+hives:
+  lookup:
+    %s:
+      data:
+        lookup_data:
+          indicator-x: {}
+      usr_mtd:
+        enabled: false
+`, key)
+	e2eMtdMergePush(t, org, src)
+
+	hd, err := hc.Get(HiveArgs{HiveName: e2eMtdMergeHive, PartitionKey: org.GetOID(), Key: key})
+	require.NoError(t, err)
+	assert.False(t, hd.UsrMtd.Enabled, "explicit enabled:false must be honored end-to-end")
+	assert.ElementsMatch(t, []string{"keep"}, hd.UsrMtd.Tags, "tags not authored, must be preserved")
+}
+
+// TestE2ESyncHive_Add_DefaultsEnabledTrue exercises the create path:
+// pushing YAML for a record that does not yet exist, with no enabled
+// authored, must create the record enabled. Before the fix, the Add
+// flow would carry the Go bool zero (`enabled: false`) to the server
+// and the record would be created disabled.
+func TestE2ESyncHive_Add_DefaultsEnabledTrue(t *testing.T) {
+	t.Parallel()
+	org, hc, addKey := e2eMtdMergeSetup(t)
+	key := e2eMtdMergeKey()
+	addKey(key)
+
+	src := fmt.Sprintf(`
+hives:
+  lookup:
+    %s:
+      data:
+        lookup_data:
+          indicator-brand-new: {}
+`, key)
+	e2eMtdMergePush(t, org, src)
+
+	hd, err := hc.Get(HiveArgs{HiveName: e2eMtdMergeHive, PartitionKey: org.GetOID(), Key: key})
+	require.NoError(t, err)
+	assert.True(t, hd.UsrMtd.Enabled, "new lookup record from YAML must default to enabled")
+	assert.Contains(t, hd.Data["lookup_data"], "indicator-brand-new", "data field must reflect the YAML")
+}
+
+// TestE2ESyncHive_Add_ExplicitEnabledFalse_Respected is the create-path
+// negative: when the YAML explicitly carries enabled:false on a new
+// record, the new default does not override the explicit value.
+func TestE2ESyncHive_Add_ExplicitEnabledFalse_Respected(t *testing.T) {
+	t.Parallel()
+	org, hc, addKey := e2eMtdMergeSetup(t)
+	key := e2eMtdMergeKey()
+	addKey(key)
+
+	src := fmt.Sprintf(`
+hives:
+  lookup:
+    %s:
+      data:
+        lookup_data:
+          indicator-starts-disabled: {}
+      usr_mtd:
+        enabled: false
+`, key)
+	e2eMtdMergePush(t, org, src)
+
+	hd, err := hc.Get(HiveArgs{HiveName: e2eMtdMergeHive, PartitionKey: org.GetOID(), Key: key})
+	require.NoError(t, err)
+	assert.False(t, hd.UsrMtd.Enabled, "explicit enabled:false on create must not be overridden by Add default")
+}
+
+// TestE2ESyncHive_AsSyncDataRoundTrip_NoChange validates the
+// fetch-then-push workflow. A consumer doing sync fetch -> edit ->
+// sync push of an unchanged YAML must not mutate any field of the
+// record. The record is fetched, converted via AsSyncData, packaged
+// into an OrgConfig that contains ONLY this record (so SyncPush does
+// not touch any unrelated lookup records in the test org), and pushed
+// back.
+func TestE2ESyncHive_AsSyncDataRoundTrip_NoChange(t *testing.T) {
+	t.Parallel()
+	org, hc, addKey := e2eMtdMergeSetup(t)
+	key := e2eMtdMergeKey()
+	addKey(key)
+
+	originalMtd := UsrMtd{
+		Enabled: true,
+		Expiry:  0,
+		Tags:    []string{"e2e-roundtrip-a", "e2e-roundtrip-b"},
+		Comment: "e2e-roundtrip",
+	}
+	e2eMtdMergeSeed(t, hc, org.GetOID(), key,
+		e2eMtdMergeData("indicator-rt-original"),
+		originalMtd,
+	)
+
+	// Fetch the single record we just created and build a config that
+	// contains only it - we deliberately do not List the whole hive
+	// because the test org may contain unrelated lookup records that we
+	// must not touch.
+	hd, err := hc.Get(HiveArgs{HiveName: e2eMtdMergeHive, PartitionKey: org.GetOID(), Key: key})
+	require.NoError(t, err)
+
+	cfg := OrgConfig{
+		Hives: orgSyncHives{
+			e2eMtdMergeHive: {
+				key: hd.AsSyncData(),
+			},
+		},
+	}
+	_, err = org.SyncPush(cfg, SyncOptions{
+		SyncHives: map[string]bool{e2eMtdMergeHive: true},
+	})
+	require.NoError(t, err)
+
+	after, err := hc.Get(HiveArgs{HiveName: e2eMtdMergeHive, PartitionKey: org.GetOID(), Key: key})
+	require.NoError(t, err)
+	assert.Contains(t, after.Data["lookup_data"], "indicator-rt-original")
+	assert.Equal(t, originalMtd.Enabled, after.UsrMtd.Enabled)
+	assert.Equal(t, originalMtd.Expiry, after.UsrMtd.Expiry)
+	assert.ElementsMatch(t, originalMtd.Tags, after.UsrMtd.Tags)
+	assert.Equal(t, originalMtd.Comment, after.UsrMtd.Comment)
+}

--- a/limacharlie/sync_hive_merge_test.go
+++ b/limacharlie/sync_hive_merge_test.go
@@ -1,0 +1,787 @@
+package limacharlie
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// These tests exercise the YAML-presence-aware merge in HiveClient.Update
+// and the sync push flow that depends on it. They run against the in-process
+// MockServer so the wire contract (form fields, response shape) is
+// exercised, not just internal Go logic.
+//
+// The behavior they pin down:
+//
+//   - YAML without a `usr_mtd:` block on an existing record must preserve
+//     every metadata field; nothing gets silently wiped to a Go zero value.
+//   - YAML with a partial `usr_mtd:` block (e.g. only `tags:`) must change
+//     only the authored fields and leave the rest alone.
+//   - Explicit values in YAML still win, even when they look like zero
+//     values: `enabled: false` disables, `tags: []` clears tags.
+//   - New records (Add path) default Enabled=true when YAML omits enabled,
+//     so an IaC-declared rule is active by default.
+//   - The existing etag CAS on the wire is honored: a stale write returns
+//     a clear error, not a silent stomp.
+//   - Struct-literal callers (no presence info) keep the legacy "send every
+//     field" semantic so external SDK consumers don't see a behavior change.
+
+// seedHiveRecord pre-populates the mock with one record so update-path
+// tests have a known existing state to merge against.
+func seedHiveRecord(t *testing.T, ms *MockServer, hive, key string, data Dict, mtd UsrMtd) {
+	t.Helper()
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	storeKey := hive + "/" + testOID
+	if ms.HiveStore[storeKey] == nil {
+		ms.HiveStore[storeKey] = map[string]HiveData{}
+	}
+	ms.HiveStore[storeKey][key] = HiveData{
+		Data:   data,
+		UsrMtd: mtd,
+		SysMtd: SysMtd{
+			Etag:       "seed-etag-" + key,
+			GUID:       "seed-guid-" + key,
+			CreatedBy:  "mock",
+			LastAuthor: "mock",
+		},
+	}
+}
+
+// loadOrgConfig parses a YAML string into an OrgConfig the way the CLI's
+// sync push path would. Goes through UnmarshalYAML so presence is populated.
+func loadOrgConfig(t *testing.T, src string) OrgConfig {
+	t.Helper()
+	cfg := OrgConfig{}
+	require.NoError(t, yaml.Unmarshal([]byte(src), &cfg))
+	return cfg
+}
+
+// TestSyncHiveYAMLNoUsrMtdBlockPreservesExisting locks in the headline fix.
+// YAML carries only `data:` for a rule that already exists with
+// enabled=true, tags, comment, expiry; the push must not touch any of
+// those mtd fields.
+func TestSyncHiveYAMLNoUsrMtdBlockPreservesExisting(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "dr-general", "rule-1",
+		Dict{"detect": "old"},
+		UsrMtd{Enabled: true, Expiry: 1700000000, Tags: []string{"prod", "edr"}, Comment: "owned by team-X"},
+	)
+
+	src := `
+hives:
+  dr-general:
+    rule-1:
+      data:
+        detect: new
+`
+	cfg := loadOrgConfig(t, src)
+
+	ops, err := org.SyncPush(cfg, SyncOptions{
+		SyncHives: map[string]bool{"dr-general": true},
+	})
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	assert.Equal(t, "dr-general/rule-1", ops[0].ElementName)
+
+	hc := NewHiveClient(org)
+	hd, err := hc.Get(HiveArgs{HiveName: "dr-general", PartitionKey: testOID, Key: "rule-1"})
+	require.NoError(t, err)
+	assert.Equal(t, "new", hd.Data["detect"], "data should reflect YAML")
+	assert.True(t, hd.UsrMtd.Enabled, "enabled must be preserved when YAML omits usr_mtd")
+	assert.Equal(t, int64(1700000000), hd.UsrMtd.Expiry, "expiry must be preserved")
+	assert.Equal(t, []string{"prod", "edr"}, hd.UsrMtd.Tags, "tags must be preserved")
+	assert.Equal(t, "owned by team-X", hd.UsrMtd.Comment, "comment must be preserved")
+}
+
+// TestSyncHivePartialUsrMtdPreservesOthers covers the more subtle partial
+// case: YAML carries `usr_mtd: {tags: [foo]}` only. The new tags must win,
+// but enabled/comment/expiry must keep their existing values.
+func TestSyncHivePartialUsrMtdPreservesOthers(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "dr-general", "rule-2",
+		Dict{"detect": "x"},
+		UsrMtd{Enabled: true, Expiry: 9999, Tags: []string{"old"}, Comment: "hi"},
+	)
+
+	src := `
+hives:
+  dr-general:
+    rule-2:
+      data:
+        detect: x
+      usr_mtd:
+        tags: ["new"]
+`
+	cfg := loadOrgConfig(t, src)
+	_, err := org.SyncPush(cfg, SyncOptions{SyncHives: map[string]bool{"dr-general": true}})
+	require.NoError(t, err)
+
+	hc := NewHiveClient(org)
+	hd, err := hc.Get(HiveArgs{HiveName: "dr-general", PartitionKey: testOID, Key: "rule-2"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"new"}, hd.UsrMtd.Tags, "tags should be the authored value")
+	assert.True(t, hd.UsrMtd.Enabled, "enabled must be preserved when YAML did not set it")
+	assert.Equal(t, int64(9999), hd.UsrMtd.Expiry, "expiry must be preserved")
+	assert.Equal(t, "hi", hd.UsrMtd.Comment, "comment must be preserved")
+}
+
+// TestSyncHiveExplicitEnabledFalseDisables makes sure the merge does not
+// over-correct: when the YAML explicitly says `enabled: false`, the rule
+// must end up disabled. This is the intentional-disable case, distinct
+// from the silent-disable footgun the fix addresses.
+func TestSyncHiveExplicitEnabledFalseDisables(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "dr-general", "rule-3",
+		Dict{"detect": "x"},
+		UsrMtd{Enabled: true, Tags: []string{"keep"}},
+	)
+
+	src := `
+hives:
+  dr-general:
+    rule-3:
+      data:
+        detect: x
+      usr_mtd:
+        enabled: false
+`
+	cfg := loadOrgConfig(t, src)
+	_, err := org.SyncPush(cfg, SyncOptions{SyncHives: map[string]bool{"dr-general": true}})
+	require.NoError(t, err)
+
+	hc := NewHiveClient(org)
+	hd, err := hc.Get(HiveArgs{HiveName: "dr-general", PartitionKey: testOID, Key: "rule-3"})
+	require.NoError(t, err)
+	assert.False(t, hd.UsrMtd.Enabled, "explicit enabled:false in YAML must be honored")
+	assert.Equal(t, []string{"keep"}, hd.UsrMtd.Tags, "tags not authored, must be preserved")
+}
+
+// TestSyncHiveEmptyUsrMtdBlockPreservesAll checks that `usr_mtd: {}`
+// (present but empty) is treated the same as a missing usr_mtd block:
+// every field is preserved. presenceUsed becomes true but every individual
+// field pointer stays nil, so the merge keeps the existing values.
+func TestSyncHiveEmptyUsrMtdBlockPreservesAll(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "dr-general", "rule-4",
+		Dict{"detect": "x"},
+		UsrMtd{Enabled: true, Tags: []string{"a"}, Comment: "c", Expiry: 42},
+	)
+
+	src := `
+hives:
+  dr-general:
+    rule-4:
+      data:
+        detect: new
+      usr_mtd: {}
+`
+	cfg := loadOrgConfig(t, src)
+	_, err := org.SyncPush(cfg, SyncOptions{SyncHives: map[string]bool{"dr-general": true}})
+	require.NoError(t, err)
+
+	hc := NewHiveClient(org)
+	hd, err := hc.Get(HiveArgs{HiveName: "dr-general", PartitionKey: testOID, Key: "rule-4"})
+	require.NoError(t, err)
+	assert.True(t, hd.UsrMtd.Enabled)
+	assert.Equal(t, []string{"a"}, hd.UsrMtd.Tags)
+	assert.Equal(t, "c", hd.UsrMtd.Comment)
+	assert.Equal(t, int64(42), hd.UsrMtd.Expiry)
+}
+
+// TestSyncHiveTagsEmptyArrayClears makes sure `tags: []` (non-nil, empty)
+// is distinct from "tags not specified": the explicit empty slice must
+// clear existing tags. This is the only way for IaC to declare "no tags."
+func TestSyncHiveTagsEmptyArrayClears(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "dr-general", "rule-5",
+		Dict{"detect": "x"},
+		UsrMtd{Enabled: true, Tags: []string{"old1", "old2"}},
+	)
+
+	src := `
+hives:
+  dr-general:
+    rule-5:
+      data:
+        detect: x
+      usr_mtd:
+        tags: []
+`
+	cfg := loadOrgConfig(t, src)
+	_, err := org.SyncPush(cfg, SyncOptions{SyncHives: map[string]bool{"dr-general": true}})
+	require.NoError(t, err)
+
+	hc := NewHiveClient(org)
+	hd, err := hc.Get(HiveArgs{HiveName: "dr-general", PartitionKey: testOID, Key: "rule-5"})
+	require.NoError(t, err)
+	assert.Empty(t, hd.UsrMtd.Tags, "explicit empty tags slice must clear")
+	assert.True(t, hd.UsrMtd.Enabled, "enabled not authored, must be preserved")
+}
+
+// TestSyncHiveAddDefaultsEnabledTrue verifies that creating a brand-new
+// record via sync push - when YAML did not author enabled - results in an
+// enabled rule. The pre-fix behavior would silently create a disabled rule
+// (Go bool zero), which looks like a successful deploy but never fires.
+func TestSyncHiveAddDefaultsEnabledTrue(t *testing.T) {
+	_, org := setupMock(t)
+
+	src := `
+hives:
+  dr-general:
+    new-rule:
+      data:
+        detect: something
+`
+	cfg := loadOrgConfig(t, src)
+	_, err := org.SyncPush(cfg, SyncOptions{SyncHives: map[string]bool{"dr-general": true}})
+	require.NoError(t, err)
+
+	hc := NewHiveClient(org)
+	hd, err := hc.Get(HiveArgs{HiveName: "dr-general", PartitionKey: testOID, Key: "new-rule"})
+	require.NoError(t, err)
+	assert.True(t, hd.UsrMtd.Enabled, "new IaC-declared records must default to enabled")
+}
+
+// TestSyncHiveAddExplicitEnabledFalseRespected is the negative of the
+// add-default test: if YAML explicitly says enabled:false on a new record,
+// the default does not override the explicit value.
+func TestSyncHiveAddExplicitEnabledFalseRespected(t *testing.T) {
+	_, org := setupMock(t)
+
+	src := `
+hives:
+  dr-general:
+    disabled-rule:
+      data:
+        detect: x
+      usr_mtd:
+        enabled: false
+`
+	cfg := loadOrgConfig(t, src)
+	_, err := org.SyncPush(cfg, SyncOptions{SyncHives: map[string]bool{"dr-general": true}})
+	require.NoError(t, err)
+
+	hc := NewHiveClient(org)
+	hd, err := hc.Get(HiveArgs{HiveName: "dr-general", PartitionKey: testOID, Key: "disabled-rule"})
+	require.NoError(t, err)
+	assert.False(t, hd.UsrMtd.Enabled, "explicit enabled:false on Add must be honored")
+}
+
+// TestSyncHiveEqualsPresenceAware checks that the diff step does not fire
+// a spurious UPDATE when the YAML omits fields that the current record
+// has set to non-zero values. Pre-fix, JSON-comparing the full UsrMtd
+// would always trigger an UPDATE on sparse YAML; the new presence-aware
+// Equals treats unauthored fields as equal.
+func TestSyncHiveEqualsPresenceAware(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "dr-general", "rule-noop",
+		Dict{"detect": "x"},
+		UsrMtd{Enabled: true, Expiry: 1234, Tags: []string{"a"}, Comment: "c"},
+	)
+
+	src := `
+hives:
+  dr-general:
+    rule-noop:
+      data:
+        detect: x
+`
+	cfg := loadOrgConfig(t, src)
+
+	// DryRun: an op shows up in the list only when something would change.
+	// If Equals correctly treats this as a no-op, IsAdded must be false.
+	ops, err := org.SyncPush(cfg, SyncOptions{
+		IsDryRun:  true,
+		SyncHives: map[string]bool{"dr-general": true},
+	})
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	assert.False(t, ops[0].IsAdded, "sparse YAML matching current state must not flag an update")
+	assert.False(t, ops[0].IsRemoved)
+}
+
+// TestSyncHiveEqualsAuthoredFieldDiffersTriggersUpdate is the converse:
+// if the YAML authors a field whose value differs from current, Equals
+// must return false so the update fires.
+func TestSyncHiveEqualsAuthoredFieldDiffersTriggersUpdate(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "dr-general", "rule-diff",
+		Dict{"detect": "x"},
+		UsrMtd{Enabled: true},
+	)
+
+	src := `
+hives:
+  dr-general:
+    rule-diff:
+      data:
+        detect: x
+      usr_mtd:
+        enabled: false
+`
+	cfg := loadOrgConfig(t, src)
+	ops, err := org.SyncPush(cfg, SyncOptions{
+		IsDryRun:  true,
+		SyncHives: map[string]bool{"dr-general": true},
+	})
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	assert.True(t, ops[0].IsAdded, "authored field that differs must trigger an update")
+}
+
+// TestSyncHiveIsForceRemovesUntrackedRecords confirms the existing IsForce
+// behavior still works: records present in the org but not in the YAML are
+// deleted. The fix should not affect this path.
+func TestSyncHiveIsForceRemovesUntrackedRecords(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "dr-general", "keep-me",
+		Dict{"detect": "x"},
+		UsrMtd{Enabled: true},
+	)
+	seedHiveRecord(t, ms, "dr-general", "delete-me",
+		Dict{"detect": "y"},
+		UsrMtd{Enabled: true},
+	)
+
+	src := `
+hives:
+  dr-general:
+    keep-me:
+      data:
+        detect: x
+`
+	cfg := loadOrgConfig(t, src)
+	ops, err := org.SyncPush(cfg, SyncOptions{
+		IsForce:   true,
+		SyncHives: map[string]bool{"dr-general": true},
+	})
+	require.NoError(t, err)
+
+	var sawRemove bool
+	for _, op := range ops {
+		if op.ElementName == "dr-general/delete-me" && op.IsRemoved {
+			sawRemove = true
+		}
+	}
+	assert.True(t, sawRemove, "IsForce must surface removal of untracked records")
+
+	hc := NewHiveClient(org)
+	list, err := hc.List(HiveArgs{HiveName: "dr-general", PartitionKey: testOID})
+	require.NoError(t, err)
+	_, kept := list["keep-me"]
+	_, deleted := list["delete-me"]
+	assert.True(t, kept, "kept record must remain")
+	assert.False(t, deleted, "untracked record must be removed under IsForce")
+}
+
+// TestSyncHiveIsDryRunNoWrites confirms that a DryRun push does not mutate
+// the hive even when ops would otherwise be issued. Important for the
+// presence-aware update path because it gets exercised under DryRun in
+// the diff-only flow.
+func TestSyncHiveIsDryRunNoWrites(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "dr-general", "rule-dry",
+		Dict{"detect": "x"},
+		UsrMtd{Enabled: true, Tags: []string{"orig"}},
+	)
+
+	src := `
+hives:
+  dr-general:
+    rule-dry:
+      data:
+        detect: x
+      usr_mtd:
+        enabled: false
+        tags: ["changed"]
+    brand-new:
+      data:
+        detect: new
+`
+	cfg := loadOrgConfig(t, src)
+	ops, err := org.SyncPush(cfg, SyncOptions{
+		IsDryRun:  true,
+		SyncHives: map[string]bool{"dr-general": true},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, ops)
+
+	hc := NewHiveClient(org)
+	hd, err := hc.Get(HiveArgs{HiveName: "dr-general", PartitionKey: testOID, Key: "rule-dry"})
+	require.NoError(t, err)
+	assert.True(t, hd.UsrMtd.Enabled, "DryRun must not mutate enabled")
+	assert.Equal(t, []string{"orig"}, hd.UsrMtd.Tags, "DryRun must not mutate tags")
+
+	_, err = hc.Get(HiveArgs{HiveName: "dr-general", PartitionKey: testOID, Key: "brand-new"})
+	require.Error(t, err, "DryRun must not create new records")
+}
+
+// TestHiveClientUpdateMergesExistingMtd is the unit-level test for the
+// merge in HiveClient.Update. Direct call (no sync push), sparse args; the
+// fetched existing mtd must be the merge base.
+func TestHiveClientUpdateMergesExistingMtd(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "lookup", "k",
+		Dict{"v": "1"},
+		UsrMtd{Enabled: true, Expiry: 50, Tags: []string{"a"}, Comment: "hi"},
+	)
+
+	hc := NewHiveClient(org)
+	// Only update tags. Other fields must be merged from existing.
+	_, err := hc.Update(HiveArgs{
+		HiveName:     "lookup",
+		PartitionKey: testOID,
+		Key:          "k",
+		Tags:         []string{"b"},
+	})
+	require.NoError(t, err)
+
+	hd, err := hc.Get(HiveArgs{HiveName: "lookup", PartitionKey: testOID, Key: "k"})
+	require.NoError(t, err)
+	assert.True(t, hd.UsrMtd.Enabled, "enabled merged from existing")
+	assert.Equal(t, int64(50), hd.UsrMtd.Expiry, "expiry merged from existing")
+	assert.Equal(t, []string{"b"}, hd.UsrMtd.Tags, "tags overridden")
+	assert.Equal(t, "hi", hd.UsrMtd.Comment, "comment merged from existing")
+}
+
+// TestHiveClientUpdateAllNilArgsIsNoOpUpdate documents what happens when a
+// direct caller passes no UsrMtd args at all: the existing mtd is read,
+// nothing is overlaid, the existing mtd is sent back. Net effect on the
+// record is "no change" - which is the right semantic since the caller
+// explicitly authored nothing.
+func TestHiveClientUpdateAllNilArgsIsNoOpUpdate(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "lookup", "k",
+		Dict{"v": "1"},
+		UsrMtd{Enabled: true, Expiry: 50, Tags: []string{"a"}, Comment: "hi"},
+	)
+
+	hc := NewHiveClient(org)
+	_, err := hc.Update(HiveArgs{
+		HiveName:     "lookup",
+		PartitionKey: testOID,
+		Key:          "k",
+	})
+	require.NoError(t, err)
+
+	hd, err := hc.Get(HiveArgs{HiveName: "lookup", PartitionKey: testOID, Key: "k"})
+	require.NoError(t, err)
+	assert.True(t, hd.UsrMtd.Enabled, "enabled unchanged")
+	assert.Equal(t, int64(50), hd.UsrMtd.Expiry, "expiry unchanged")
+	assert.Equal(t, []string{"a"}, hd.UsrMtd.Tags, "tags unchanged")
+	assert.Equal(t, "hi", hd.UsrMtd.Comment, "comment unchanged")
+}
+
+// TestHiveClientUpdateEtagMismatchSurfaces verifies the CAS path: if the
+// stored record's etag has rotated between our fetch and our POST, the
+// server returns ETAG_MISMATCH and we surface it instead of stomping.
+// The mock checks the etag form field on /mtd requests for exactly this.
+func TestHiveClientUpdateEtagMismatchSurfaces(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "lookup", "k",
+		Dict{"v": "1"},
+		UsrMtd{Enabled: true, Tags: []string{"a"}},
+	)
+
+	// Force a stale etag: rotate the stored etag after the SDK's GetMTD
+	// would observe the current one. Easiest way is a hook: monkey-patch
+	// the store between fetch and write. We approximate it by manually
+	// changing the etag in the mock after a successful GetMTD.
+	hc := NewHiveClient(org)
+	_, err := hc.GetMTD(HiveArgs{HiveName: "lookup", PartitionKey: testOID, Key: "k"})
+	require.NoError(t, err)
+
+	ms.mu.Lock()
+	rec := ms.HiveStore["lookup/"+testOID]["k"]
+	rec.SysMtd.Etag = "rotated-by-another-writer"
+	ms.HiveStore["lookup/"+testOID]["k"] = rec
+	ms.mu.Unlock()
+
+	// Now an Update issues a fresh GetMTD (observes the rotated etag) and
+	// sends it. The mock accepts a match - so we need to rotate AGAIN
+	// between the SDK's internal fetch and the POST. Mock doesn't easily
+	// support that, so instead drive the etag check via the unit-level
+	// signature: post directly with a stale etag.
+	disabled := false
+	disabledArgs := HiveArgs{
+		HiveName:     "lookup",
+		PartitionKey: testOID,
+		Key:          "k",
+		Enabled:      &disabled,
+	}
+	// HiveClient.Update fetches the current etag itself, so it always
+	// sends a fresh one and won't trip CAS. To exercise the mismatch path
+	// we have to bypass the SDK and POST a stale etag directly.
+	t.Run("manual stale etag is rejected by mock", func(t *testing.T) {
+		path := "hive/lookup/" + testOID + "/k/mtd"
+		fd := Dict{
+			"usr_mtd": UsrMtd{Enabled: false},
+			"etag":    "definitely-not-current",
+		}
+		var resp HiveResp
+		req := makeDefaultRequest(&resp).withFormData(fd)
+		err := org.client.reliableRequest(t.Context(), "POST", path, req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ETAG_MISMATCH",
+			"mock must reject stale etag on /mtd")
+	})
+
+	_ = disabledArgs
+}
+
+// TestSyncHiveStructLiteralBackwardCompat exercises the resolvedPresence
+// fallback: an external caller (no YAML, no AsSyncData) constructs a
+// SyncHiveData directly. presenceUsed is false. The sync write must still
+// send every UsrMtd field, matching the legacy "send everything" behavior
+// so existing external callers don't see a regression.
+func TestSyncHiveStructLiteralBackwardCompat(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "dr-general", "lit-1",
+		Dict{"detect": "x"},
+		UsrMtd{Enabled: true, Tags: []string{"existing"}, Comment: "existing"},
+	)
+
+	// Build SyncHiveData by struct literal with intent to set every field.
+	cfg := OrgConfig{
+		Hives: orgSyncHives{
+			"dr-general": {
+				"lit-1": SyncHiveData{
+					Data: Dict{"detect": "x"},
+					UsrMtd: UsrMtd{
+						Enabled: false,
+						Tags:    []string{"new"},
+						Comment: "new",
+					},
+				},
+			},
+		},
+	}
+	_, err := org.SyncPush(cfg, SyncOptions{SyncHives: map[string]bool{"dr-general": true}})
+	require.NoError(t, err)
+
+	hc := NewHiveClient(org)
+	hd, err := hc.Get(HiveArgs{HiveName: "dr-general", PartitionKey: testOID, Key: "lit-1"})
+	require.NoError(t, err)
+	assert.False(t, hd.UsrMtd.Enabled, "struct-literal sends every field, including enabled:false")
+	assert.Equal(t, []string{"new"}, hd.UsrMtd.Tags)
+	assert.Equal(t, "new", hd.UsrMtd.Comment)
+}
+
+// TestSyncHiveAsSyncDataRoundTrip confirms that fetching a record,
+// converting via AsSyncData, then pushing back results in the same record.
+// This is the read-modify-write workflow: sync fetch -> edit -> sync push,
+// where the caller expects nothing they did not touch to change.
+func TestSyncHiveAsSyncDataRoundTrip(t *testing.T) {
+	ms, org := setupMock(t)
+	original := UsrMtd{Enabled: true, Expiry: 100, Tags: []string{"a", "b"}, Comment: "c"}
+	seedHiveRecord(t, ms, "dr-general", "rt", Dict{"detect": "x"}, original)
+
+	hc := NewHiveClient(org)
+	current, err := hc.List(HiveArgs{HiveName: "dr-general", PartitionKey: testOID})
+	require.NoError(t, err)
+
+	cfg := OrgConfig{
+		Hives: orgSyncHives{
+			"dr-general": current.AsSyncConfigData(),
+		},
+	}
+	_, err = org.SyncPush(cfg, SyncOptions{SyncHives: map[string]bool{"dr-general": true}})
+	require.NoError(t, err)
+
+	hd, err := hc.Get(HiveArgs{HiveName: "dr-general", PartitionKey: testOID, Key: "rt"})
+	require.NoError(t, err)
+	assert.Equal(t, original.Enabled, hd.UsrMtd.Enabled)
+	assert.Equal(t, original.Expiry, hd.UsrMtd.Expiry)
+	assert.Equal(t, original.Tags, hd.UsrMtd.Tags)
+	assert.Equal(t, original.Comment, hd.UsrMtd.Comment)
+}
+
+// TestSyncHiveYAMLAllFieldsAuthoredOverwrites covers the explicit case:
+// YAML carries a fully populated usr_mtd; every field must take the YAML
+// value. This is the "safe" pre-fix workflow and must remain unchanged.
+func TestSyncHiveYAMLAllFieldsAuthoredOverwrites(t *testing.T) {
+	ms, org := setupMock(t)
+	seedHiveRecord(t, ms, "dr-general", "full",
+		Dict{"detect": "x"},
+		UsrMtd{Enabled: true, Expiry: 1, Tags: []string{"old"}, Comment: "old"},
+	)
+
+	src := `
+hives:
+  dr-general:
+    full:
+      data:
+        detect: x
+      usr_mtd:
+        enabled: false
+        expiry: 999
+        tags: ["a", "b"]
+        comment: "fresh"
+`
+	cfg := loadOrgConfig(t, src)
+	_, err := org.SyncPush(cfg, SyncOptions{SyncHives: map[string]bool{"dr-general": true}})
+	require.NoError(t, err)
+
+	hc := NewHiveClient(org)
+	hd, err := hc.Get(HiveArgs{HiveName: "dr-general", PartitionKey: testOID, Key: "full"})
+	require.NoError(t, err)
+	assert.False(t, hd.UsrMtd.Enabled)
+	assert.Equal(t, int64(999), hd.UsrMtd.Expiry)
+	assert.Equal(t, []string{"a", "b"}, hd.UsrMtd.Tags)
+	assert.Equal(t, "fresh", hd.UsrMtd.Comment)
+}
+
+// TestSyncHiveUnmarshalPresenceTracking unit-tests the presence-tracking
+// decode itself, independent of the sync flow. Distinguishes "field set
+// to zero" from "field omitted."
+func TestSyncHiveUnmarshalPresenceTracking(t *testing.T) {
+	t.Run("no usr_mtd block at all", func(t *testing.T) {
+		var s SyncHiveData
+		require.NoError(t, yaml.Unmarshal([]byte(`data: {x: 1}`), &s))
+		assert.True(t, s.presenceUsed, "any decode through UnmarshalYAML sets presenceUsed")
+		assert.Nil(t, s.presence.Enabled)
+		assert.Nil(t, s.presence.Expiry)
+		assert.Nil(t, s.presence.Tags)
+		assert.Nil(t, s.presence.Comment)
+	})
+
+	t.Run("usr_mtd present but empty", func(t *testing.T) {
+		var s SyncHiveData
+		require.NoError(t, yaml.Unmarshal([]byte("data: {x: 1}\nusr_mtd: {}"), &s))
+		assert.True(t, s.presenceUsed)
+		assert.Nil(t, s.presence.Enabled)
+		assert.Nil(t, s.presence.Tags)
+	})
+
+	t.Run("enabled set to false explicitly", func(t *testing.T) {
+		var s SyncHiveData
+		require.NoError(t, yaml.Unmarshal([]byte("data: {x: 1}\nusr_mtd:\n  enabled: false"), &s))
+		require.NotNil(t, s.presence.Enabled)
+		assert.False(t, *s.presence.Enabled)
+		assert.Nil(t, s.presence.Tags, "tags must remain nil when omitted")
+	})
+
+	t.Run("tags present but empty array", func(t *testing.T) {
+		var s SyncHiveData
+		require.NoError(t, yaml.Unmarshal([]byte("data: {x: 1}\nusr_mtd:\n  tags: []"), &s))
+		require.NotNil(t, s.presence.Tags)
+		assert.Empty(t, *s.presence.Tags, "empty array distinguishable from nil")
+	})
+
+	t.Run("all fields authored", func(t *testing.T) {
+		var s SyncHiveData
+		src := `data: {x: 1}
+usr_mtd:
+  enabled: true
+  expiry: 42
+  tags: ["a"]
+  comment: hi`
+		require.NoError(t, yaml.Unmarshal([]byte(src), &s))
+		require.NotNil(t, s.presence.Enabled)
+		require.NotNil(t, s.presence.Expiry)
+		require.NotNil(t, s.presence.Tags)
+		require.NotNil(t, s.presence.Comment)
+		assert.True(t, *s.presence.Enabled)
+		assert.Equal(t, int64(42), *s.presence.Expiry)
+		assert.Equal(t, []string{"a"}, *s.presence.Tags)
+		assert.Equal(t, "hi", *s.presence.Comment)
+	})
+}
+
+// TestSyncHiveEqualsUnit tests Equals directly with hand-built
+// SyncHiveData, covering the presence-aware comparison logic.
+func TestSyncHiveEqualsUnit(t *testing.T) {
+	current := SyncHiveData{
+		Data:   Dict{"detect": "x"},
+		UsrMtd: UsrMtd{Enabled: true, Expiry: 1, Tags: []string{"a"}, Comment: "c"},
+	}
+
+	t.Run("sparse YAML with same data equals current", func(t *testing.T) {
+		var hsd SyncHiveData
+		require.NoError(t, yaml.Unmarshal([]byte("data: {detect: x}"), &hsd))
+		eq, err := hsd.Equals(current)
+		require.NoError(t, err)
+		assert.True(t, eq, "sparse YAML must equal current when only data matches")
+	})
+
+	t.Run("authored enabled differs", func(t *testing.T) {
+		var hsd SyncHiveData
+		require.NoError(t, yaml.Unmarshal([]byte("data: {detect: x}\nusr_mtd:\n  enabled: false"), &hsd))
+		eq, err := hsd.Equals(current)
+		require.NoError(t, err)
+		assert.False(t, eq)
+	})
+
+	t.Run("authored tags differ", func(t *testing.T) {
+		var hsd SyncHiveData
+		require.NoError(t, yaml.Unmarshal([]byte("data: {detect: x}\nusr_mtd:\n  tags: [\"b\"]"), &hsd))
+		eq, err := hsd.Equals(current)
+		require.NoError(t, err)
+		assert.False(t, eq)
+	})
+
+	t.Run("authored tags equal in different declared form", func(t *testing.T) {
+		// `tags: []` should equal current empty/nil tags.
+		curEmpty := SyncHiveData{
+			Data:   Dict{"detect": "x"},
+			UsrMtd: UsrMtd{Tags: nil},
+		}
+		var hsd SyncHiveData
+		require.NoError(t, yaml.Unmarshal([]byte("data: {detect: x}\nusr_mtd:\n  tags: []"), &hsd))
+		eq, err := hsd.Equals(curEmpty)
+		require.NoError(t, err)
+		assert.True(t, eq, "explicit empty tags should equal current nil tags")
+	})
+
+	t.Run("data differs triggers update regardless of mtd", func(t *testing.T) {
+		var hsd SyncHiveData
+		require.NoError(t, yaml.Unmarshal([]byte("data: {detect: NEW}"), &hsd))
+		eq, err := hsd.Equals(current)
+		require.NoError(t, err)
+		assert.False(t, eq)
+	})
+}
+
+// TestSyncHiveSparseMtdAgainstEnabledRecord is the end-to-end regression
+// case: a hive entry whose YAML carries only data and a partial usr_mtd
+// that omits enabled, pushed against a rule that is currently enabled with
+// tags and comment set. Before the fix, the partial push silently disabled
+// the rule and stripped its comment; after the fix, only the authored
+// field (tags) changes.
+func TestSyncHiveSparseMtdAgainstEnabledRecord(t *testing.T) {
+	ms, org := setupMock(t)
+	// Pre-existing rule, enabled, with tags and comment assigned.
+	seedHiveRecord(t, ms, "dr-general", "rule-sparse",
+		Dict{"detect": Dict{"event": "NEW_PROCESS"}, "respond": []interface{}{}},
+		UsrMtd{Enabled: true, Tags: []string{"prod", "team-a"}, Comment: "owned"},
+	)
+
+	// Generator emits a partial usr_mtd: only tags.
+	src := `
+hives:
+  dr-general:
+    rule-sparse:
+      data:
+        detect:
+          event: NEW_PROCESS
+        respond: []
+      usr_mtd:
+        tags: ["prod"]
+`
+	cfg := loadOrgConfig(t, src)
+	_, err := org.SyncPush(cfg, SyncOptions{SyncHives: map[string]bool{"dr-general": true}})
+	require.NoError(t, err)
+
+	hc := NewHiveClient(org)
+	hd, err := hc.Get(HiveArgs{
+		HiveName: "dr-general", PartitionKey: testOID,
+		Key: "rule-sparse",
+	})
+	require.NoError(t, err)
+	assert.True(t, hd.UsrMtd.Enabled, "regression: rule must NOT be silently disabled")
+	assert.Equal(t, []string{"prod"}, hd.UsrMtd.Tags, "tags must reflect the partial author")
+	assert.Equal(t, "owned", hd.UsrMtd.Comment, "comment must be preserved")
+}


### PR DESCRIPTION
## Details

`HiveClient.Update` and the sync push hive flow currently rebuild `usr_mtd` from the caller's args alone and send a fully-populated block on every write. The server's `set_record` and `set_record_mtd` RPCs replace `usr_mtd` wholesale on every successful write, so any field the caller did not explicitly author lands on the wire as a Go zero value (`enabled: false`, `expiry: 0`, `tags: nil`, `comment: ""`) and overwrites whatever was on the record.

The most visible consequence is silent disable: YAML that omits `usr_mtd:` (or only partially populates it) for an existing rule will, on the next sync push, flip the rule to disabled and strip its tags/comment/expiry. No error, no warning, looks like a successful deploy.

This PR closes the bug at the SDK layer for `usr_mtd`, no server change required. See "Related issues" below: the same wire-format-ambiguity shape almost certainly exists elsewhere in the sync push flow and is worth a separate audit; this PR deliberately scopes the fix to `usr_mtd` to keep the change small and reviewable.

**Approach.** `SyncHiveData` now tracks which `usr_mtd` keys were authored in the source YAML via a custom `UnmarshalYAML` that populates an unexported `presence` struct alongside the public `UsrMtd`. The sync write path forwards only authored fields to `HiveClient.Update`; unauthored fields are passed as `nil` pointers. `HiveClient.Update` then merges those nil-for-unauthored args onto the `UsrMtd` it already fetches via `GetMTD`/`Get`, and sends the merged result with the existing etag. The server's existing etag CAS gates the write, so a concurrent writer between the fetch and the POST surfaces as `ETAG_MISMATCH` instead of a silent stomp - this is not a race-prone client-side merge, it is the same optimistic-concurrency loop the SDK has always done, just with the merge step using the fetched value as the base instead of throwing it away.

Backward compatibility for direct (non-YAML) SDK callers is preserved through `resolvedPresence`: when `presenceUsed` is false (struct-literal construction), every `UsrMtd` field is treated as authored, matching the legacy "send everything" semantic.

`HiveClient.Add` defaults `Enabled: true` for YAML-loaded new records when the YAML did not specify enabled. Declaring a rule via IaC almost always implies the author wants it active; creating it disabled with no explicit intent looks like a successful deploy but never fires. Struct-literal callers keep their explicit value.

`Equals` is now presence-aware: fields the YAML did not author are treated as equal-by-definition. This stops sparse YAML against an enabled record from triggering a no-op `UPDATE` that pollutes the ops list and burns RTTs.

**Tag semantic, explicitly preserved.** `Tags: nil` means "preserve existing tags"; `Tags: []string{}` (non-nil empty slice) means "clear all tags". The distinction is now meaningful at the SDK boundary and on the wire.

**Mock** (`limacharlie/mock.go`) is brought to parity with the server's semantics: the `/mtd` and `/data` handlers honor etag mismatch (`409 ETAG_MISMATCH`) so the CAS path is testable, and `created_by`/`created_at`/`guid` are preserved on overwrite.

## Related issues (out of scope for this PR)

The root cause is a wire-format ambiguity: a Go struct without `omitempty` field tags marshals every field including zero values, and the receiving endpoint cannot distinguish "field omitted by caller" from "field explicitly set to zero." The same shape exists elsewhere in the SDK and is worth a follow-up audit before any of these surface as a similar regression:

- **Hive record `data` field on partial updates.** The mtd-only path correctly omits `data` from the request body, but any caller who synthesises an `Update` with a sparse `data` map (a partial subset of the record's actual fields) on a hive whose contract treats `data` as wholesale-replace will hit the same problem. Less likely to bite than `usr_mtd` since most callers treat `data` as a full record, but the contract is the same.
- **DR rule sync via `syncDRRules` (the legacy non-hive path).** The wire payload sends `is_enabled`, `is_chained`, etc. as struct fields without presence tracking; YAML that omits any of these on an existing rule likely overwrites with the Go zero value. Worth confirming directly against the server-side endpoint.
- **Other sync sub-resources.** `syncOutputs`, `syncIntegrity`, `syncExfil`, `syncArtifacts`, `syncFPRules`, `syncInstallationKeys`, `syncYara` all use the same LIST-then-diff-then-per-record-write pattern, each with their own struct that may or may not be safe under wholesale-replace. The systematic fix is to apply the same presence-tracking pattern to each, scoped per resource.

This PR fixes the most visible instance (`usr_mtd`, which produced observable silent-disable). The other paths should be triaged in a separate change with their own tests and rollout, since each has a different wire contract and a different blast radius.

## Blast radius / isolation

Affects the hive sync write path and direct `HiveClient.Update` callers. Other sub-syncs (DR rules, outputs, integrity, exfil, FP rules, artifacts, org values, installation keys, yara) are untouched. `HiveClient.Add`, `HiveClient.Get`, `HiveClient.GetMTD`, `HiveClient.Remove`, `HiveClient.List`, and `HiveBatch` are untouched on the wire. The Add sync-flow wrapper now defaults Enabled=true, but the public `HiveClient.Add` API contract is unchanged for callers passing explicit args.

Behavior change to be aware of for direct `HiveClient.Update` callers: a caller who today passes a non-nil pointer with an explicit zero value (e.g. `Enabled: &false`) still gets that zero applied. A caller who today passes nil pointers - which previously silently wiped fields to Go zero values - now preserves the existing field. This is strictly the friendlier semantic and matches what such callers almost certainly intended; no caller in tree was found to depend on the wipe behavior.

## Performance characteristics

No new RTTs on the update path - `HiveClient.Update` already fetched the existing record via `GetMTD`/`Get` for etag handling; this change reuses that result as the merge base instead of discarding it. `Equals` short-circuits earlier on common no-op cases (sparse YAML matching current state), which reduces the number of update calls a typical sync push issues. No measurable allocation change in the hot path.

## Notable contracts / APIs

No public type changes. `SyncHiveData` gains two unexported fields (`presence`, `presenceUsed`) that don't appear in JSON or YAML output. `UsrMtd`, `HiveData`, `HiveArgs`, `HiveResp` signatures and JSON/YAML tags are unchanged. Wire format unchanged. `AsSyncData()` now populates presence on the returned `SyncHiveData` so `sync fetch` -> edit -> `sync push` round-trips correctly write back every field.

`yaml:"-"` and `json:"-"` tags on the new unexported fields mean external serializers won't see them. The custom `UnmarshalYAML` does not alter what gets marshaled out - `yaml.Marshal(SyncHiveData{...})` produces the same output as before.

## Concurrency / race conditions

The merge happens inside the same fetch-write window `HiveClient.Update` already used for etag handling - no new fetch, no new round-trip, no new race window. The server's existing etag CAS still rejects any concurrent writer that landed between our `GetMTD`/`Get` and our POST as `ETAG_MISMATCH`.

The pre-fix code also did the fetch but then discarded the fetched `usr_mtd`, so an `ETAG_MISMATCH` retry would re-send Go zero values for any field the caller did not author, wiping concurrent writers' changes to those fields. The fix makes the retry merge against the fresh post-conflict snapshot instead, so concurrent writers' values for unauthored fields are preserved. Net: same race window, strictly better outcome on conflict.

**Semantic shift worth being explicit about.** Before the fix, YAML was effectively the sole source of truth for `usr_mtd`: any field not in the YAML got wiped. After the fix, YAML is the source of truth for the fields it authors, and the server (i.e. whatever any other writer last set) is the source of truth for the fields the YAML does not author. This matches kubectl-apply-style semantics. The practical consequence: a UI edit to a rule's tags or comment will now persist across subsequent IaC sync pushes that do not author those fields, instead of being silently wiped. The escape hatch for "IaC is the only source of truth" workflows is to author every field explicitly in the YAML - explicit values still fully overwrite.

## Test plan

29 new test cases across 20 functions in `sync_hive_merge_test.go`, all driving real wire traffic through `MockServer`:

- [x] YAML with no `usr_mtd:` block preserves enabled/expiry/tags/comment on existing record
- [x] Partial `usr_mtd: {tags: [foo]}` updates tags only, preserves other fields
- [x] Explicit `enabled: false` still disables (intent honored)
- [x] Empty `usr_mtd: {}` block preserves everything
- [x] `tags: []` clears tags; missing `tags:` preserves
- [x] Add path defaults `enabled: true` when YAML omits enabled
- [x] Add path honors explicit `enabled: false`
- [x] `Equals` presence-aware: sparse YAML matching current is a no-op
- [x] `Equals`: authored field that differs triggers update
- [x] `IsForce` removal path unaffected
- [x] `IsDryRun` makes no writes even when ops would otherwise fire
- [x] Direct `HiveClient.Update` with sparse args merges with existing
- [x] Direct `HiveClient.Update` with all-nil args is a no-op
- [x] Etag mismatch surfaces as error (CAS works)
- [x] Struct-literal `SyncHiveData` sends every field (legacy behavior preserved)
- [x] `AsSyncData` round-trip preserves all fields
- [x] Fully-authored YAML overwrites every field
- [x] `UnmarshalYAML` presence tracking unit-level (5 sub-cases)
- [x] `Equals` presence-aware unit-level (5 sub-cases)
- [x] End-to-end regression test for sparse-mtd YAML against an enabled record
