### PR TITLE
output: add cc_email and bcc_email to SMTP OutputConfig

### DIFF
--- a/limacharlie/output.go
+++ b/limacharlie/output.go
@@ -131,6 +131,8 @@ type OutputConfig struct {
 	SecondsPerFile    int    `json:"sec_per_file,omitempty,string" yaml:"sec_per_file,omitempty"`
 	SampleRate        int    `json:"sample_rate,omitempty,string" yaml:"sample_rate,omitempty"`
 	DestinationEmail  string `json:"dest_email,omitempty" yaml:"dest_email,omitempty"`
+	CCEmail           string `json:"cc_email,omitempty" yaml:"cc_email,omitempty"`
+	BCCEmail          string `json:"bcc_email,omitempty" yaml:"bcc_email,omitempty"`
 	FromEmail         string `json:"from_email,omitempty" yaml:"from_email,omitempty"`
 	Readable          bool   `json:"is_readable,omitempty,string" yaml:"is_readable,omitempty"`
 	Subject           string `json:"subject,omitempty" yaml:"subject,omitempty"`


### PR DESCRIPTION
## Summary

Adds `CCEmail` (`cc_email`) and `BCCEmail` (`bcc_email`) string fields to the SMTP `OutputConfig` so the new multi-recipient SMTP output can be configured through the Go SDK.

`dest_email` already accepts a comma-separated list of addresses; these two new optional fields add comma-separated Cc and Bcc recipient lists.

## Related PRs (tracking refractionPOINT/tracking#4317)

- Backend (parsing/sending): refractionPOINT/legion_endpoint-go#1241
- Manager (config allow-list): see linked PR in tracking issue
- Docs: see linked PR in tracking issue

Backward compatible — both fields are `omitempty`, so existing serialized configs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)