### PR TITLE
sensor: allow setting page limit on ListSensorsFromSelectorIteratively

### DIFF
--- a/limacharlie/sensor.go
+++ b/limacharlie/sensor.go
@@ -353,24 +353,36 @@ func (org *Organization) ListSensorsFromSelector(selector string) (map[string]*S
 	return m, nil
 }
 
-func (org *Organization) ListSensorsFromSelectorIteratively(ctx context.Context, selector string, continuationToken string) (map[string]*Sensor, string, error) {
+// ListSensorsIterativeOptions configures behavior of ListSensorsFromSelectorIteratively.
+type ListSensorsIterativeOptions struct {
+	// Limit caps the number of sensor records returned per call. Leaving it
+	// zero defers to the backend default. Set a smaller value to bound the
+	// per-call latency when paginating through large organizations.
+	Limit int
+}
+
+func (org *Organization) ListSensorsFromSelectorIteratively(ctx context.Context, selector string, continuationToken string, options ...ListSensorsIterativeOptions) (map[string]*Sensor, string, error) {
 	m := map[string]*Sensor{}
 	lastToken := continuationToken
 
+	effectiveOptions := ListSensorsIterativeOptions{}
+	if len(options) != 0 {
+		effectiveOptions = options[0]
+	}
+
 	page := rawSensorListPage{}
 	q := makeDefaultRequest(&page)
-	if lastToken != "" {
-		q = q.withQueryData(Dict{
-			"continuation_token": lastToken,
-			"selector":           selector,
-			"is_compressed":      "true",
-		})
-	} else {
-		q = q.withQueryData(Dict{
-			"selector":      selector,
-			"is_compressed": "true",
-		})
+	queryData := Dict{
+		"selector":      selector,
+		"is_compressed": "true",
 	}
+	if lastToken != "" {
+		queryData["continuation_token"] = lastToken
+	}
+	if effectiveOptions.Limit > 0 {
+		queryData["limit"] = effectiveOptions.Limit
+	}
+	q = q.withQueryData(queryData)
 	if err := org.client.reliableRequest(ctx, http.MethodGet, fmt.Sprintf("sensors/%s", org.client.options.OID), q); err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
## Summary

- Accept variadic `ListSensorsIterativeOptions` on `ListSensorsFromSelectorIteratively`, exposing a `Limit` field that flows through as the `limit` query parameter.
- Today the function builds the query with only `continuation_token`, `selector`, and `is_compressed`. Without `limit`, the backend uses its default page size, which for large organizations can produce single-page scans long enough to approach the gateway timeout. Callers paginating through such orgs benefit from being able to cap each page explicitly.
- Backward compatible: existing callers continue to compile unchanged. With no options or `Limit == 0`, the request is identical to today.

## Effect

Setting `Limit: N` causes the SDK to send `limit=N` in the query string, bounding per-page work. Callers that iterate through many sensors and want predictable per-call latency can opt in. Default behavior is preserved for everyone else.

## Test plan

- [ ] Existing iterative callers compile without source changes (variadic option, no breaking change).
- [ ] Manual verification of query string content with and without `Limit` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)