### PR TITLE
Add org_notes, sop to KnownHives

### DIFF
--- a/limacharlie/sync.go
+++ b/limacharlie/sync.go
@@ -66,6 +66,8 @@ var KnownHives = []string{
 	"ai_skill",
 	"ai_memory",
 	"external_adapter",
+	"org_notes",
+	"sop",
 }
 
 func SyncAll() SyncOptions {
@@ -97,6 +99,8 @@ func SyncAll() SyncOptions {
 			"ai_skill":         true,
 			"ai_memory":        true,
 			"external_adapter": true,
+			"org_notes":        true,
+			"sop":              true,
 		},
 	}
 }


### PR DESCRIPTION
## Summary
Adds the `org_notes` and `sop` config hives to `KnownHives` and the `SyncAll()` default `SyncHives` map in `limacharlie/sync.go`.

These hives are defined in `legion_config_hive` but were missing from the SDK's `KnownHives`, so downstream consumers that build their hive list from it (notably `ext-git-sync`) did not expose them as syncable/exportable toggles.

`investigation`, `extension_subscription` and `extension_definition` were intentionally left out (not per-org user-syncable config).

## Test
- `go build ./...` passes, `gofmt` clean.
- Remaining `sync_test.go` failures are the existing live-integration tests that require `_OID` credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)