### PR TITLE
client: allow overriding API and JWT URLs via ClientOptions

### DIFF
--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -46,6 +46,10 @@ type ClientOptions struct {
 	Environment   string
 	Permissions   []string
 	JWTExpiryTime time.Duration
+	// URL overrides the default REST API base URL ("https://api.limacharlie.io") when non-empty.
+	URL string
+	// JWTURL overrides the default JWT exchange URL ("https://jwt.limacharlie.io") when non-empty.
+	JWTURL string
 }
 
 type jwtResponse struct {
@@ -105,7 +109,7 @@ func isEmpty(s string) bool {
 // Will return a valid client as soon as one loader returns valid requirements
 func NewClientFromLoader(inOpt ClientOptions, logger LCLogger, optsLoaders ...ClientOptionLoader) (*Client, error) {
 	if inOpt.validateMinimumRequirements() == nil && inOpt.validate() == nil {
-		return &Client{options: inOpt, logger: logger, httpClient: getHTTPClient(), baseURL: rootURL, jwtURL: getJWTURL}, nil
+		return &Client{options: inOpt, logger: logger, httpClient: getHTTPClient(), baseURL: resolveBaseURL(inOpt.URL), jwtURL: resolveJWTURL(inOpt.JWTURL)}, nil
 	}
 
 	loaderCount := len(optsLoaders)
@@ -135,9 +139,25 @@ func NewClientFromLoader(inOpt ClientOptions, logger LCLogger, optsLoaders ...Cl
 		options:    opt,
 		logger:     logger,
 		httpClient: getHTTPClient(),
-		baseURL:    rootURL,
-		jwtURL:     getJWTURL,
+		baseURL:    resolveBaseURL(opt.URL),
+		jwtURL:     resolveJWTURL(opt.JWTURL),
 	}, nil
+}
+
+// resolveBaseURL returns the override when non-empty, otherwise the default rootURL.
+func resolveBaseURL(override string) string {
+	if override != "" {
+		return override
+	}
+	return rootURL
+}
+
+// resolveJWTURL returns the override when non-empty, otherwise the default getJWTURL.
+func resolveJWTURL(override string) string {
+	if override != "" {
+		return override
+	}
+	return getJWTURL
 }
 
 // NewClient loads client options from

--- a/limacharlie/client_test.go
+++ b/limacharlie/client_test.go
@@ -55,3 +55,27 @@ func (s *ClientTestSuite) TestFileLoader() {
 		})
 	}
 }
+
+func (s *ClientTestSuite) TestDefaultURLs() {
+	c, err := NewClientFromLoader(ClientOptions{
+		OID: "9416bc29-2bae-47d7-ac8c-63210f3a22e3",
+		JWT: "fake",
+	}, nil)
+	if s.NoError(err) {
+		s.Equal(rootURL, c.baseURL)
+		s.Equal(getJWTURL, c.jwtURL)
+	}
+}
+
+func (s *ClientTestSuite) TestURLOverrides() {
+	c, err := NewClientFromLoader(ClientOptions{
+		OID:    "9416bc29-2bae-47d7-ac8c-63210f3a22e3",
+		JWT:    "fake",
+		URL:    "https://api.example.test",
+		JWTURL: "https://jwt.example.test",
+	}, nil)
+	if s.NoError(err) {
+		s.Equal("https://api.example.test", c.baseURL)
+		s.Equal("https://jwt.example.test", c.jwtURL)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `URL` and `JWTURL` fields to `ClientOptions` so callers can point the SDK at a non-default LimaCharlie cluster (self-hosted instances, staging, or local test fixtures) without resorting to reflection, forks, or network-layer rewrites.
- Both fields default to the existing `rootURL` / `getJWTURL` constants when left empty, so every existing caller continues to talk to `https://api.limacharlie.io` and `https://jwt.limacharlie.io` with no change in behavior.
- Wired through both construction paths in \`NewClientFromLoader\` (the fast path when options already validate, and the loader-chain path).

## Why

Today the prod API endpoint is baked into `client.go` as the package-level `rootURL` constant, and `Client.baseURL` is private with no public setter. The only escape hatch is the in-package mock. Anyone wanting to point the SDK at a non-prod cluster has to fork or patch via `reflect`+`unsafe` — both fragile. This change gives callers a clean, documented option.

## Test plan

- [x] `go build ./...` passes.
- [x] New `TestDefaultURLs` confirms unset fields fall back to `rootURL` / `getJWTURL`.
- [x] New `TestURLOverrides` confirms non-empty fields override both endpoints.
- [ ] Existing test suite passes in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)