### PR TITLE
Support explicit-scheme replay/query endpoints

### DIFF
--- a/limacharlie/query.go
+++ b/limacharlie/query.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -103,7 +104,7 @@ func (org *Organization) QueryWithContext(ctx context.Context, req QueryRequest)
 	}
 
 	// Build the URL
-	url := fmt.Sprintf("https://%s/", replayURL)
+	url := replayQueryURL(replayURL)
 
 	// Create the HTTP request
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
@@ -236,7 +237,7 @@ func (qi *QueryIterator) Next() (*QueryResponse, error) {
 	}
 
 	// Build the URL
-	url := fmt.Sprintf("https://%s/", qi.replayURL)
+	url := replayQueryURL(qi.replayURL)
 
 	// Create the HTTP request
 	httpReq, err := http.NewRequestWithContext(qi.ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
@@ -294,4 +295,16 @@ func (qi *QueryIterator) Next() (*QueryResponse, error) {
 // HasMore returns true if there are more pages of results to fetch.
 func (qi *QueryIterator) HasMore() bool {
 	return qi.hasMore
+}
+
+// replayQueryURL builds the endpoint URL from a replay/query host. A bare host
+// is resolved to https; a host that already carries an explicit scheme (e.g.
+// "http://...") is used as-is, which lets the SDK target an endpoint served
+// over a non-default scheme (for example a plain-HTTP endpoint in development
+// or testing).
+func replayQueryURL(replayURL string) string {
+	if strings.Contains(replayURL, "://") {
+		return strings.TrimRight(replayURL, "/") + "/"
+	}
+	return "https://" + replayURL + "/"
 }

--- a/limacharlie/replay.go
+++ b/limacharlie/replay.go
@@ -231,8 +231,9 @@ func (org *Organization) ReplayDRRuleWithContext(ctx context.Context, req Replay
 		return nil, fmt.Errorf("failed to marshal request body: %v", err)
 	}
 
-	// Build the URL
-	url := fmt.Sprintf("https://%s/", replayURL)
+	// Build the URL (replayQueryURL honors an explicit scheme on the host and
+	// defaults to https for a bare host — see query.go).
+	url := replayQueryURL(replayURL)
 
 	// Create the HTTP request
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))

--- a/limacharlie/validation.go
+++ b/limacharlie/validation.go
@@ -149,8 +149,8 @@ func (org *Organization) ValidateLCQLQueryWithContext(ctx context.Context, query
 		return nil, fmt.Errorf("failed to marshal request body: %v", err)
 	}
 
-	// Build the URL
-	url := fmt.Sprintf("https://%s/", replayURL)
+	// Build the URL (scheme-aware; see replayQueryURL in query.go).
+	url := replayQueryURL(replayURL)
 
 	// Create the HTTP request
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
@@ -287,8 +287,8 @@ func (org *Organization) EstimateLCQLQueryBillingWithContext(ctx context.Context
 		return nil, fmt.Errorf("failed to marshal request body: %v", err)
 	}
 
-	// Build the URL
-	url := fmt.Sprintf("https://%s/", replayURL)
+	// Build the URL (scheme-aware; see replayQueryURL in query.go).
+	url := replayQueryURL(replayURL)
 
 	// Create the HTTP request
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
@@ -544,8 +544,8 @@ func (org *Organization) ValidateDRRuleWithContext(ctx context.Context, rule Dic
 		return nil, fmt.Errorf("failed to marshal request body: %v", err)
 	}
 
-	// Build the URL
-	url := fmt.Sprintf("https://%s/", replayURL)
+	// Build the URL (scheme-aware; see replayQueryURL in query.go).
+	url := replayQueryURL(replayURL)
 
 	// Create the HTTP request
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))


### PR DESCRIPTION
## Support explicit-scheme replay/query endpoints

`Query`, `ReplayDRRule`, and the LCQL validation/estimate helpers built the replay endpoint URL by hardcoding `https://` in front of the host returned by `GetURLs()`. That made it impossible to target an endpoint served over a different scheme (for example a plain-HTTP endpoint used in local development or testing).

This adds a small helper, `replayQueryURL`, which:
- uses the host's scheme as-is when it already carries one (`http://…` / `https://…`),
- defaults a bare host to `https://` — unchanged behaviour for existing callers.

`Query`, `QueryIterator.Next`, `ReplayDRRule`, and `ValidateLCQLQuery` / `EstimateLCQLQueryBilling` / `ValidateDRRule` all route through it. No behavioural change for hosts returned today (bare host → `https`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
