### PR TITLE
Handle array-shaped response in ListAvailableExtensions

### DIFF
--- a/limacharlie/org_extras.go
+++ b/limacharlie/org_extras.go
@@ -145,10 +145,10 @@ func (org *Organization) ListAvailableExtensions() (Dict, error) {
 		return nil, fmt.Errorf("failed to list available extensions: %w", err)
 	}
 
-	// The endpoint may return either a JSON object (e.g. keyed by extension name,
-	// or wrapping a list under a field) or a bare JSON array of extension
-	// definitions, each carrying a "name". Normalize the array form into a
-	// name-keyed object so callers always receive a Dict.
+	// The endpoint returns a JSON array of extension definitions, each carrying a
+	// "name". Normalize it into a name-keyed object so callers always receive a
+	// Dict. A JSON object response is handled as a defensive fallback (e.g. a
+	// name-keyed object from a mock or older backend).
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) > 0 && trimmed[0] == '[' {
 		var list []Dict

--- a/limacharlie/org_extras.go
+++ b/limacharlie/org_extras.go
@@ -1,6 +1,8 @@
 package limacharlie
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -138,9 +140,35 @@ func (org *Organization) ExportSensors() (Dict, error) {
 // It mirrors python-limacharlie Extensions.get_all (sdk/extensions.py ~L63),
 // issuing a GET against extension/definition.
 func (org *Organization) ListAvailableExtensions() (Dict, error) {
-	resp := Dict{}
-	if err := org.GenericGETRequest("extension/definition", Dict{}, &resp); err != nil {
+	var raw json.RawMessage
+	if err := org.GenericGETRequest("extension/definition", Dict{}, &raw); err != nil {
 		return nil, fmt.Errorf("failed to list available extensions: %w", err)
+	}
+
+	// The endpoint may return either a JSON object (e.g. keyed by extension name,
+	// or wrapping a list under a field) or a bare JSON array of extension
+	// definitions, each carrying a "name". Normalize the array form into a
+	// name-keyed object so callers always receive a Dict.
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var list []Dict
+		if err := json.Unmarshal(trimmed, &list); err != nil {
+			return nil, fmt.Errorf("failed to list available extensions: %w", err)
+		}
+		out := Dict{}
+		for _, ext := range list {
+			if name, _ := ext["name"].(string); name != "" {
+				out[name] = ext
+			}
+		}
+		return out, nil
+	}
+
+	resp := Dict{}
+	if len(trimmed) > 0 {
+		if err := json.Unmarshal(trimmed, &resp); err != nil {
+			return nil, fmt.Errorf("failed to list available extensions: %w", err)
+		}
 	}
 	return resp, nil
 }


### PR DESCRIPTION
## Problem

`ListAvailableExtensions` issues a `GET` against `extension/definition`. That endpoint's response is a **JSON array** of extension definitions, each carrying a `name`. The previous implementation decoded straight into a `map[string]interface{}`, so the call failed with `cannot unmarshal array into map[string]interface{}`.

## Fix

Decode into a raw message first, then normalize the array into a `name`-keyed `Dict` so callers get a stable, lookup-friendly map keyed by extension name. `name` is present on every definition, so no entries are dropped.

A JSON object response is still handled as a defensive fallback (e.g. a name-keyed object from a mock or older backend), so that path keeps working too — but the array is the shape the endpoint actually returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
