### PR TITLE
Support explicit scheme in artifact upload URL

### DIFF
--- a/limacharlie/artifact.go
+++ b/limacharlie/artifact.go
@@ -130,7 +130,13 @@ func (org *Organization) UploadArtifact(data io.Reader, size int64, hint string,
 	if !ok {
 		return errors.New("artifacts URL not found in org URLs")
 	}
-	reqUrl := fmt.Sprintf("https://%s/ingest", uploadUrl)
+	// A bare host is resolved to https; a host that already carries an explicit
+	// scheme (e.g. http://host:port) is used as-is, so callers can point at a
+	// non-default scheme (for example a plain-HTTP endpoint in development).
+	if !strings.Contains(uploadUrl, "://") {
+		uploadUrl = "https://" + uploadUrl
+	}
+	reqUrl := uploadUrl + "/ingest"
 
 	// Build request
 	combined := fmt.Sprintf("%s:%s", org.GetOID(), ingestionKey)


### PR DESCRIPTION
## What

`UploadArtifact` hardcoded an `https://` prefix on the organization's artifacts URL. This change respects a scheme that is already present on the URL, and only defaults a bare host to `https`.

```go
if !strings.Contains(uploadUrl, "://") {
    uploadUrl = "https://" + uploadUrl
}
reqUrl := uploadUrl + "/ingest"
```

## Why

Lets callers target a non-default scheme (for example a plain-HTTP endpoint in a development environment) without changing the default behaviour for normal `host` values, which continue to resolve to `https`.

## Test

`go build ./...` and `go vet ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164kZQFjibDGNV2WCGgAfMP