### PR TITLE
APIKeyInfo: map the creator field from "by" (backend key), document absent created_at

### DIFF
--- a/limacharlie/organization_ext.go
+++ b/limacharlie/organization_ext.go
@@ -52,14 +52,19 @@ type ListUserOrgsOptions struct {
 
 // APIKeyInfo contains information about an API key
 type APIKeyInfo struct {
-	KeyHash        string   `json:"key_hash,omitempty"`
-	Description    string   `json:"name,omitempty"` // API returns "name" from Firebase
-	Permissions    []string `json:"priv,omitempty"` // API returns "priv"
-	CreatedAt      int64    `json:"created_at,omitempty"`
-	CreatedBy      string   `json:"created_by,omitempty"`
-	OID            string   `json:"oid,omitempty"`
-	AllowedIPRange string   `json:"allowed_ip_range,omitempty"`
-	LastUsed       int64    `json:"last_used,omitempty"`
+	KeyHash     string   `json:"key_hash,omitempty"`
+	Description string   `json:"name,omitempty"` // API returns "name" from Firebase
+	Permissions []string `json:"priv,omitempty"` // API returns "priv"
+	// CreatedAt is NOT returned by GET /orgs/{oid}/keys (the backend response
+	// carries no creation timestamp) — it stays zero on listings and is kept only
+	// for compatibility with callers that populate it out-of-band.
+	CreatedAt int64 `json:"created_at,omitempty"`
+	// CreatedBy is the creator's identity (the JWT ident — an email for
+	// interactively-created keys). The API returns it under the key "by".
+	CreatedBy      string `json:"by,omitempty"`
+	OID            string `json:"oid,omitempty"`
+	AllowedIPRange string `json:"allowed_ip_range,omitempty"`
+	LastUsed       int64  `json:"last_used,omitempty"`
 }
 
 // APIKeyCreate contains the response when creating a new API key


### PR DESCRIPTION
## What was asked
Final cross-review of the new limacharlie cloudsec provider found that `APIKeyInfo.CreatedBy` never populates: the SDK tag is `created_by`, but `GET /orgs/{oid}/keys` returns the creator ident under `by` (lc_api-go `sp_getOrgApiKeys`, response schema in `endpoint_org_info.go`). `CreatedAt` is not in the listing response at all.

## What was done
- `CreatedBy` json tag → `by` (field name unchanged; value is the creator's JWT ident — an email for interactively-created keys).
- Doc comment on `CreatedAt`: not returned by the listing; stays zero (kept for out-of-band callers).

## Testing
`go build` clean. The package's tests require live-org env credentials (`_OID` etc.) and were not run here; the change is a struct-tag fix validated against the gateway's response schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KDJBHDL3CcF4jP1u32Xy2