### PR TITLE
Surface real options-validation error in NewClientFromLoader

### DIFF
--- a/limacharlie/client.go
+++ b/limacharlie/client.go
@@ -141,13 +141,20 @@ func isEmpty(s string) bool {
 // NewClientFromLoader initialize a client from options loaders.
 // Will return a valid client as soon as one loader returns valid requirements
 func NewClientFromLoader(inOpt ClientOptions, logger LCLogger, optsLoaders ...ClientOptionLoader) (*Client, error) {
-	if inOpt.validateMinimumRequirements() == nil && inOpt.validate() == nil {
+	errMin := inOpt.validateMinimumRequirements()
+	errVal := inOpt.validate()
+	if errMin == nil && errVal == nil {
 		return &Client{options: inOpt, logger: logger, httpClient: getHTTPClient(), baseURL: resolveBaseURL(inOpt.URL), jwtURL: resolveJWTURL(inOpt.JWTURL)}, nil
 	}
 
 	loaderCount := len(optsLoaders)
 	if loaderCount == 0 {
-		return nil, newLCError(lcErrClientNoOptionsLoader)
+		// No loaders to fall back on, so surface the actual reason the inline
+		// options were rejected instead of a generic "no loader" error.
+		if errMin != nil {
+			return nil, errMin
+		}
+		return nil, errVal
 	}
 
 	var opt ClientOptions

--- a/limacharlie/client_test.go
+++ b/limacharlie/client_test.go
@@ -16,8 +16,24 @@ func TestClientSuite(t *testing.T) {
 }
 
 func (s *ClientTestSuite) TestNoLoader() {
+	// With no loaders and empty options, the client should surface the actual
+	// validation failure (missing minimum requirements) rather than a generic
+	// "no loader" error.
 	c, err := NewClientFromLoader(ClientOptions{}, nil)
-	s.EqualError(err, newLCError(lcErrClientNoOptionsLoader).Error())
+	s.EqualError(err, newLCError(lcErrClientMissingRequirements).Error())
+	s.Nil(c)
+}
+
+func (s *ClientTestSuite) TestNoLoaderInvalidAPIKey() {
+	// Minimum requirements are met (a valid OID is set) but the APIKey is not a
+	// valid UUID. With no loaders to fall back on, the underlying validation
+	// error must be surfaced instead of being masked.
+	c, err := NewClientFromLoader(ClientOptions{
+		OID:    "9416bc29-2bae-47d7-ac8c-63210f3a22e3",
+		APIKey: "not-a-valid-uuid",
+	}, nil)
+	s.Error(err)
+	s.Contains(err.Error(), "invalid APIKey")
 	s.Nil(c)
 }
 

--- a/limacharlie/errors.go
+++ b/limacharlie/errors.go
@@ -9,7 +9,6 @@ import (
 type lcErrorCode = string
 
 const (
-	lcErrClientNoOptionsLoader     = "CLIENT_NO_OPTION_LOADER"
 	lcErrClientMissingRequirements = "CLIENT_MISSING_REQUIREMENTS"
 )
 


### PR DESCRIPTION
## Problem

`NewClientFromLoader` masks the underlying options-validation error when called with no loaders.

When the function is invoked with zero option loaders and inline `ClientOptions` that fail validation, it returns a generic `CLIENT_NO_OPTION_LOADER` error and discards the real reason the options were rejected. For example, passing a valid `OID` alongside an `APIKey` that is not a valid UUID yields the nonsense "no loader" error instead of the accurate "invalid APIKey" message, making bad credentials passed to the SDK undiagnosable.

This affects the deliberate hermetic usage pattern where a caller supplies inline options with no loaders on purpose (to avoid ambient environment/file credential resolution).

## Fix

In `NewClientFromLoader`, the minimum-requirements and full validation errors are now computed once up front. When no loaders are supplied, the actual validation error is returned:
- the missing-requirements error when minimum requirements are unmet, otherwise
- the field-level validation error (e.g. "invalid APIKey: ...").

Behavior when loaders are present is unchanged.

The `lcErrClientNoOptionsLoader` code became unreferenced and has been removed.

## Tests

- Updated `TestNoLoader` to expect the missing-requirements error for empty options with no loaders.
- Added `TestNoLoaderInvalidAPIKey`: valid OID + non-UUID APIKey, zero loaders, asserts the error mentions "invalid APIKey".

Pre-existing suite tests that require credentials/env vars still fail locally exactly as before (no new failures introduced); the client-suite tests that do not need env vars all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MQDFDeFHmYRyR9DT3vRnj