### PR TITLE
Move the test-runner image off the EOL golang:1.15 base

### DIFF
--- a/limacharlie/Dockerfile
+++ b/limacharlie/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.26
 
 ENV LC_CURRENT_ENV "test_env"
 ENV LC_OID "fba6e992-ce4f-4d9e-99dc-b548f00df7f9"


### PR DESCRIPTION
## Summary

`limacharlie/Dockerfile` pins `golang:1.15` — released 2020, unsupported for years — so the image carries a long tail of known CVEs in both the base layer and the bundled toolchain. Bumps it to the floating `golang:1.26` tag, which picks up patch releases automatically.

## Scope: this is base-image hygiene, not a build fix

Worth being precise, because a version bump like this can look like it fixes a broken build. It does not. **Nothing in this Dockerfile compiles Go** — it `ADD`s the `limacharlie.test` binary that CI produces and runs it:

```dockerfile
ADD limacharlie.test .
ADD tests ./tests
CMD ["./limacharlie.test", "-test.v", "-test.run", "^.*$"]
```

So the tag only selects the base image. There is no release currently failing because of it.

## How it surfaced

A sweep comparing Dockerfile builder Go versions against `go.mod` directives across all repos flagged this as `builder go1.15 < go1.25.9 required by firehose/go.mod`. On investigation the `go.mod` comparison is not meaningful here (no compilation happens), but the 2020 base image is a real finding in its own right.

Using the floating `golang:1.26` rather than a pinned patch means this will not drift again on patch releases.

## Test plan

- [x] Built the image locally after compiling a `limacharlie.test` stand-in with `go test -c` (CI normally supplies it) — **image builds successfully**
- [x] `docker run --entrypoint go … version` in the built image reports **go1.26.5**
- [x] Working tree contains only the Dockerfile change; the locally compiled test binary was removed and not committed

Docker emits pre-existing lint advisories on this file (`LegacyKeyValueFormat` on the `ENV` lines, and `SecretsUsedInArgOrEnv` for the test `LC_API_KEY`). Both predate this change and are untouched — the API key is a test-environment credential already in the file, and reformatting the `ENV` lines would widen the diff beyond the base bump.

Found alongside related release-pipeline work in refractionPOINT/tracking#4556.
